### PR TITLE
chore: 書籍内のサンプル日付を2026-01-01に更新

### DIFF
--- a/books/ai-spec-driven-development-90percent/part1_why-ai-fails/02_ai-weakness.md
+++ b/books/ai-spec-driven-development-90percent/part1_why-ai-fails/02_ai-weakness.md
@@ -307,7 +307,7 @@ POST /api/v1/users
   "id": "uuid",
   "email": "user@example.com",
   "username": "johndoe",
-  "createdAt": "2024-01-01T00:00:00Z"
+  "createdAt": "2026-01-01T00:00:00Z"
 }
 ```
 

--- a/books/ai-spec-driven-development-90percent/part2_spec-is-90percent/04_seven-documents.md
+++ b/books/ai-spec-driven-development-90percent/part2_spec-is-90percent/04_seven-documents.md
@@ -90,12 +90,12 @@ MASTER.mdは**AIが最初に読む文書**です。
 ## 文書索引
 | 文書 | 説明 | 更新日 |
 |------|------|--------|
-| [PROJECT.md](./PROJECT.md) | ビジョン・要件 | 2024-01-01 |
-| [ARCHITECTURE.md](./ARCHITECTURE.md) | システム設計 | 2024-01-01 |
-| [DOMAIN.md](./DOMAIN.md) | ビジネスロジック | 2024-01-01 |
-| [PATTERNS.md](./PATTERNS.md) | 実装パターン | 2024-01-01 |
-| [TESTING.md](./TESTING.md) | テスト戦略 | 2024-01-01 |
-| [DEPLOYMENT.md](./DEPLOYMENT.md) | 運用手順 | 2024-01-01 |
+| [PROJECT.md](./PROJECT.md) | ビジョン・要件 | 2026-01-01 |
+| [ARCHITECTURE.md](./ARCHITECTURE.md) | システム設計 | 2026-01-01 |
+| [DOMAIN.md](./DOMAIN.md) | ビジネスロジック | 2026-01-01 |
+| [PATTERNS.md](./PATTERNS.md) | 実装パターン | 2026-01-01 |
+| [TESTING.md](./TESTING.md) | テスト戦略 | 2026-01-01 |
+| [DEPLOYMENT.md](./DEPLOYMENT.md) | 運用手順 | 2026-01-01 |
 
 ## ディレクトリ構造
 ```text

--- a/books/ai-spec-driven-development-90percent/part2_spec-is-90percent/05_minimum-rules.md
+++ b/books/ai-spec-driven-development-90percent/part2_spec-is-90percent/05_minimum-rules.md
@@ -30,7 +30,7 @@ title: ARCHITECTURE.md
 version: 1.2.0
 status: approved
 owner: "@tech-lead"
-created: 2024-01-01
+created: 2026-01-01
 updated: 2024-03-15
 reviewers:
   - "@senior-dev"
@@ -50,7 +50,7 @@ reviewers:
 | version | セマンティックバージョン | 1.2.0 |
 | status | 文書の状態 | draft / review / approved |
 | owner | 責任者 | @username |
-| created | 作成日 | 2024-01-01 |
+| created | 作成日 | 2026-01-01 |
 | updated | 最終更新日 | 2024-03-15 |
 
 ### オプションフィールド

--- a/books/ai-spec-driven-development-90percent/part3_practice/06_introduction.md
+++ b/books/ai-spec-driven-development-90percent/part3_practice/06_introduction.md
@@ -60,8 +60,8 @@ title: MASTER.md
 version: 0.1.0
 status: draft
 owner: "@your-name"
-created: 2024-01-01
-updated: 2024-01-01
+created: 2026-01-01
+updated: 2026-01-01
 ---
 
 # プロジェクト名
@@ -100,8 +100,8 @@ title: PROJECT.md
 version: 0.1.0
 status: draft
 owner: "@your-name"
-created: 2024-01-01
-updated: 2024-01-01
+created: 2026-01-01
+updated: 2026-01-01
 ---
 
 # PROJECT.md
@@ -136,8 +136,8 @@ title: ARCHITECTURE.md
 version: 0.1.0
 status: draft
 owner: "@your-name"
-created: 2024-01-01
-updated: 2024-01-01
+created: 2026-01-01
+updated: 2026-01-01
 ---
 
 # ARCHITECTURE.md

--- a/books/ai-spec-driven-development-90percent/part4_faq/11_quality-security.md
+++ b/books/ai-spec-driven-development-90percent/part4_faq/11_quality-security.md
@@ -226,7 +226,7 @@ jobs:
 
 ```bash
 # いつ、誰が、何を変えたか
-git log --oneline --author="name" --since="2024-01-01"
+git log --oneline --author="name" --since="2026-01-01"
 
 # 特定のファイルの変更履歴
 git log --follow -p -- path/to/file


### PR DESCRIPTION
## Summary

書籍内の例示用日付を `2024-01-01` から `2026-01-01` に更新しました。

## 変更ファイル

- `part1_why-ai-fails/02_ai-weakness.md`
- `part2_spec-is-90percent/04_seven-documents.md`
- `part2_spec-is-90percent/05_minimum-rules.md`
- `part3_practice/06_introduction.md`
- `part4_faq/11_quality-security.md`

## Test plan

- [ ] 日付が正しく更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * AI駆動開発仕様ガイドの複数ドキュメントにおけるメタデータを更新しました。

* **その他の変更**
  * ドキュメント内の日付参照を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->