### PR TITLE
docs: AIツールの記載を汎用的な表現に変更

### DIFF
--- a/books/ai-spec-driven-development-90percent/part3_practice/07_daily-workflow.md
+++ b/books/ai-spec-driven-development-90percent/part3_practice/07_daily-workflow.md
@@ -252,16 +252,19 @@ Issue #42 を実装してください。
 3. 影響を受ける既存ファイルの変更点
 ```
 
-### Claude Codeを使う場合
+### AIコーディングツールを使う場合
 
-Claude Codeでは、Issueの内容をそのまま渡せます。
+Claude Code、GitHub Copilot、Cursorなど、いずれのツールでもIssueの内容をそのまま渡せます。
 
 ```bash
-# GitHubのIssueを直接参照
+# Claude Codeの例
 claude "Issue #42 を実装して。docs/配下の仕様に従って。"
+
+# GitHub Copilot（チャット）の例
+# @workspace Issue #42 を実装して。docs/配下の仕様に従って。
 ```
 
-7文書がリポジトリにあれば、Claude Codeは自動的に参照します。
+7文書がリポジトリにあれば、AIツールは自動的に参照します。
 
 ---
 


### PR DESCRIPTION
## Summary

第7章の「Claude Codeを使う場合」セクションを、GitHub CopilotやCursorも含む汎用的な表現に変更しました。

## 変更内容

**Before:**
- 「Claude Codeを使う場合」
- Claude Code固有の説明

**After:**
- 「AIコーディングツールを使う場合」
- Claude Code、GitHub Copilot、Cursorなど複数ツールに対応
- GitHub Copilotの使用例を追加

## Test plan

- [ ] 説明が汎用的で分かりやすいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)