### PR TITLE
feat(book): #178 「AIエージェント開発は仕様が9割」ペーパーバック対応 v1.0.0

### DIFF
--- a/books/ai-spec-driven-development-90percent/book-config.js
+++ b/books/ai-spec-driven-development-90percent/book-config.js
@@ -38,7 +38,7 @@ module.exports = {
     subtitle: 'Vibe Codingで失敗しないための設計図',
     author: 'Futoshi Okazaki',
     language: 'ja',
-    version: '0.1.0',
+    version: '1.0.0',
     date: '2026-01-01',
     coverImage: 'images/cover.jpg',
     description: 'AIコーディングツール（Claude Code, GitHub Copilot, Cursor等）を活用したいエンジニア向けの実践ガイド。AI仕様駆動開発の考え方と7文書構成を導入して、AIに安心して開発を任せられるようになる。',

--- a/books/ai-spec-driven-development-90percent/build-paperback-cover.js
+++ b/books/ai-spec-driven-development-90percent/build-paperback-cover.js
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+/**
+ * ペーパーバック表紙生成スクリプト
+ *
+ * 既存の電子書籍表紙をベースに、ペーパーバック用の表紙（表・背・裏）を生成する。
+ *
+ * 使い方:
+ *   node build-paperback-cover.js [ページ数]
+ *   node build-paperback-cover.js 200
+ *
+ * 依存:
+ *   - ImageMagick (magick コマンド)
+ */
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const bookConfig = require('./book-config');
+
+// === 設定 ===
+const CONFIG = {
+  // 判型（トリムサイズ）- 5.83 x 8.27 インチ（A5）
+  trimWidth: 5.83,     // インチ
+  trimHeight: 8.27,    // インチ
+
+  // 裁ち落とし
+  bleed: 0.125,        // インチ（各辺）
+
+  // 解像度
+  dpi: 300,
+
+  // 用紙タイプ（背幅計算用）
+  // クリーム紙: 0.0025 インチ/ページ
+  // 白紙: 0.002 インチ/ページ
+  pageThickness: 0.0025,
+
+  // 色設定
+  backgroundColor: '#1a1a1a',  // 裏表紙・背表紙の背景色
+  textColor: '#ffffff',        // テキスト色
+  accentColor: '#3182CE',      // アクセント色（ブルー）
+
+  // フォント（日本語対応フォント）
+  fontFamily: '.Hiragino-Kaku-Gothic-Interface-W4',
+  fontFamilyLight: '.Hiragino-Kaku-Gothic-Interface-W2',
+  fontFamilyBold: '.Hiragino-Kaku-Gothic-Interface-W5',
+
+  // 入出力ファイル
+  inputCover: 'images/cover.jpg',
+  outputCoverJpg: 'images/cover_paperback.jpg',
+  outputCoverPdf: 'images/cover_paperback.pdf',
+};
+
+// === ヘルパー関数 ===
+
+/**
+ * インチをピクセルに変換
+ */
+function inchToPixel(inch) {
+  return Math.round(inch * CONFIG.dpi);
+}
+
+/**
+ * 背幅を計算（ページ数から）
+ */
+function calculateSpineWidth(pageCount) {
+  return pageCount * CONFIG.pageThickness;
+}
+
+/**
+ * ImageMagickがインストールされているか確認
+ */
+function checkImageMagick() {
+  const result = spawnSync('magick', ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+/**
+ * ImageMagickコマンドを実行
+ */
+function runMagick(args) {
+  console.log(`  実行: magick ${args.slice(0, 3).join(' ')}...`);
+  const result = spawnSync('magick', args, {
+    cwd: __dirname,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  if (result.status !== 0) {
+    const stderr = result.stderr ? result.stderr.toString() : '';
+    throw new Error(`ImageMagickエラー: ${stderr}`);
+  }
+
+  return result;
+}
+
+/**
+ * 表紙サイズを計算
+ */
+function calculateCoverSize(pageCount) {
+  const spineWidth = calculateSpineWidth(pageCount);
+
+  // 各要素のサイズ（インチ）
+  const frontWidth = CONFIG.trimWidth;
+  const backWidth = CONFIG.trimWidth;
+
+  // 全体サイズ（裁ち落とし込み）
+  const totalWidth = backWidth + spineWidth + frontWidth + (CONFIG.bleed * 2);
+  const totalHeight = CONFIG.trimHeight + (CONFIG.bleed * 2);
+
+  return {
+    spineWidth,
+    totalWidth,
+    totalHeight,
+    // ピクセル値
+    spineWidthPx: inchToPixel(spineWidth),
+    totalWidthPx: inchToPixel(totalWidth),
+    totalHeightPx: inchToPixel(totalHeight),
+    frontWidthPx: inchToPixel(frontWidth + CONFIG.bleed),
+    backWidthPx: inchToPixel(backWidth + CONFIG.bleed),
+    bleedPx: inchToPixel(CONFIG.bleed),
+  };
+}
+
+/**
+ * 背表紙画像を生成
+ */
+function createSpineImage(size, tempDir) {
+  const spinePath = path.join(tempDir, 'spine.png');
+  const title = bookConfig.metadata.title;
+  const author = bookConfig.metadata.author;
+
+  // 背表紙のテキスト
+  // 背幅が狭い場合（100px未満）はフォントサイズを小さくする
+  const fontSize = size.spineWidthPx < 100 ? 12 : 16;
+  const spineText = `${title}　　${author}`;
+
+  // ベース画像を作成
+  runMagick([
+    '-size', `${size.spineWidthPx}x${size.totalHeightPx}`,
+    `xc:${CONFIG.backgroundColor}`,
+    spinePath
+  ]);
+
+  // 回転してテキストを配置（背表紙は通常90度回転）
+  // 一時的に回転した画像を作成
+  const rotatedPath = path.join(tempDir, 'spine_rotated.png');
+  runMagick([
+    '-size', `${size.totalHeightPx}x${size.spineWidthPx}`,
+    `xc:${CONFIG.backgroundColor}`,
+    '-fill', CONFIG.textColor,
+    '-font', CONFIG.fontFamily,
+    '-pointsize', `${fontSize}`,
+    '-gravity', 'center',
+    '-annotate', '+0+0', spineText,
+    rotatedPath
+  ]);
+
+  // 90度回転して背表紙の向きに
+  runMagick([
+    rotatedPath,
+    '-rotate', '-90',
+    spinePath
+  ]);
+
+  return spinePath;
+}
+
+/**
+ * 裏表紙画像を生成
+ */
+function createBackCoverImage(size, tempDir) {
+  const backPath = path.join(tempDir, 'back.png');
+
+  // ベース画像を作成
+  runMagick([
+    '-size', `${size.backWidthPx}x${size.totalHeightPx}`,
+    `xc:${CONFIG.backgroundColor}`,
+    backPath
+  ]);
+
+  // キャッチコピー（上部）
+  runMagick([
+    backPath,
+    '-fill', CONFIG.accentColor,
+    '-font', CONFIG.fontFamilyBold,
+    '-pointsize', '36',
+    '-gravity', 'north',
+    '-annotate', '+0+200', 'Vibe Codingを成功させる「設計図」',
+    backPath
+  ]);
+
+  // メインテキスト（中央）
+  runMagick([
+    backPath,
+    '-fill', CONFIG.textColor,
+    '-font', CONFIG.fontFamily,
+    '-pointsize', '28',
+    '-gravity', 'center',
+    '-annotate', '+0-100', '7文書体系で\nAIエージェント開発を制する',
+    backPath
+  ]);
+
+  // キーメッセージ（中央下）
+  runMagick([
+    backPath,
+    '-fill', CONFIG.textColor,
+    '-font', CONFIG.fontFamilyLight,
+    '-pointsize', '32',
+    '-gravity', 'center',
+    '-annotate', '+0+150', '仕様が9割。AIは残りの1割。',
+    backPath
+  ]);
+
+  // 特徴（下部）
+  const features = '✓ Claude Code / GitHub Copilot / Cursor 対応\n✓ 7文書テンプレート付き\n✓ 実践的なワークフロー解説';
+  runMagick([
+    backPath,
+    '-fill', '#cccccc',
+    '-font', CONFIG.fontFamilyLight,
+    '-pointsize', '22',
+    '-gravity', 'south',
+    '-annotate', '+0+300', features,
+    backPath
+  ]);
+
+  // 姉妹編の紹介（最下部）
+  runMagick([
+    backPath,
+    '-fill', '#888888',
+    '-font', CONFIG.fontFamilyLight,
+    '-pointsize', '18',
+    '-gravity', 'south',
+    '-annotate', '+0+150', '姉妹編「小さく指示すれば、AIは正確になる。」も好評発売中',
+    backPath
+  ]);
+
+  // バーコード領域（KDP必須: 裏表紙右下に2" x 1.2"の白い領域）
+  // 位置: 右下から裁ち落とし分だけ内側
+  const barcodeWidth = inchToPixel(2);
+  const barcodeHeight = inchToPixel(1.2);
+  const barcodeMargin = inchToPixel(0.25); // 端からのマージン
+  runMagick([
+    backPath,
+    '-fill', 'white',
+    '-draw', `rectangle ${size.backWidthPx - barcodeWidth - barcodeMargin},${size.totalHeightPx - barcodeHeight - barcodeMargin} ${size.backWidthPx - barcodeMargin},${size.totalHeightPx - barcodeMargin}`,
+    backPath
+  ]);
+
+  return backPath;
+}
+
+/**
+ * 表表紙をリサイズ
+ */
+function resizeFrontCover(size, tempDir) {
+  const frontPath = path.join(tempDir, 'front.png');
+  const inputPath = path.join(__dirname, CONFIG.inputCover);
+
+  if (!fs.existsSync(inputPath)) {
+    throw new Error(`表紙画像が見つかりません: ${inputPath}`);
+  }
+
+  // 表表紙サイズにリサイズ（裁ち落とし込み）
+  const frontWidth = size.frontWidthPx;
+  const frontHeight = size.totalHeightPx;
+
+  runMagick([
+    inputPath,
+    '-resize', `${frontWidth}x${frontHeight}^`,
+    '-gravity', 'center',
+    '-extent', `${frontWidth}x${frontHeight}`,
+    frontPath
+  ]);
+
+  return frontPath;
+}
+
+/**
+ * 全体を結合
+ */
+function combineCovers(backPath, spinePath, frontPath, size) {
+  const outputPathJpg = path.join(__dirname, CONFIG.outputCoverJpg);
+  const outputPathPdf = path.join(__dirname, CONFIG.outputCoverPdf);
+
+  // JPGで結合
+  runMagick([
+    backPath, spinePath, frontPath,
+    '+append',  // 横に結合
+    '-quality', '95',
+    outputPathJpg
+  ]);
+
+  // PDFに変換（300DPI）
+  runMagick([
+    outputPathJpg,
+    '-density', '300',
+    '-units', 'PixelsPerInch',
+    outputPathPdf
+  ]);
+
+  return { jpg: outputPathJpg, pdf: outputPathPdf };
+}
+
+/**
+ * メイン処理
+ */
+function main() {
+  console.log('='.repeat(60));
+  console.log('ペーパーバック表紙生成スクリプト');
+  console.log('='.repeat(60));
+  console.log('');
+
+  // ページ数を取得
+  const pageCount = parseInt(process.argv[2]) || 200;
+  console.log(`ページ数: ${pageCount}`);
+
+  // ImageMagick確認
+  if (!checkImageMagick()) {
+    console.error('エラー: ImageMagickがインストールされていません');
+    console.error('  brew install imagemagick');
+    process.exit(1);
+  }
+
+  // サイズ計算
+  const size = calculateCoverSize(pageCount);
+  console.log('');
+  console.log('表紙サイズ:');
+  console.log(`  全体: ${size.totalWidthPx} x ${size.totalHeightPx} px`);
+  console.log(`  背幅: ${size.spineWidthPx} px (${size.spineWidth.toFixed(3)} インチ)`);
+  console.log('');
+
+  // 一時ディレクトリ
+  const tempDir = path.join(__dirname, '.temp_cover');
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir);
+  }
+
+  try {
+    // 1. 表表紙をリサイズ
+    console.log('[1/4] 表表紙をリサイズ...');
+    const frontPath = resizeFrontCover(size, tempDir);
+    console.log('  ✓ 完了');
+
+    // 2. 背表紙を生成
+    console.log('[2/4] 背表紙を生成...');
+    const spinePath = createSpineImage(size, tempDir);
+    console.log('  ✓ 完了');
+
+    // 3. 裏表紙を生成
+    console.log('[3/4] 裏表紙を生成...');
+    const backPath = createBackCoverImage(size, tempDir);
+    console.log('  ✓ 完了');
+
+    // 4. 結合 & PDF変換
+    console.log('[4/4] 画像を結合 & PDF変換...');
+    const outputPaths = combineCovers(backPath, spinePath, frontPath, size);
+    console.log('  ✓ 完了');
+
+    // クリーンアップ
+    fs.rmSync(tempDir, { recursive: true });
+
+    // 結果表示
+    const statsPdf = fs.statSync(outputPaths.pdf);
+    const fileSizeMB = (statsPdf.size / 1024 / 1024).toFixed(2);
+
+    console.log('');
+    console.log('='.repeat(60));
+    console.log('生成完了!');
+    console.log('='.repeat(60));
+    console.log(`PDF: ${CONFIG.outputCoverPdf}`);
+    console.log(`JPG: ${CONFIG.outputCoverJpg}`);
+    console.log(`サイズ: ${size.totalWidthPx} x ${size.totalHeightPx} px (300 DPI)`);
+    console.log(`ファイルサイズ: ${fileSizeMB} MB`);
+    console.log('');
+    console.log('KDPにアップロード: PDFファイルを使用');
+    console.log('');
+
+  } catch (error) {
+    // エラー時もクリーンアップ
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+    console.error('');
+    console.error('エラー:', error.message);
+    process.exit(1);
+  }
+}
+
+// 実行
+main();

--- a/books/ai-spec-driven-development-90percent/build-paperback-pdf.js
+++ b/books/ai-spec-driven-development-90percent/build-paperback-pdf.js
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+/**
+ * ペーパーバック本文PDF生成スクリプト
+ *
+ * KDPペーパーバック用の本文PDFを生成する。
+ *
+ * 処理の流れ:
+ * 1. Markdownファイルを結合（章番号付与）
+ * 2. Pandoc + weasyprint でPDFを生成（ペーパーバック用CSS適用）
+ * 3. 一時ファイルをクリーンアップ
+ *
+ * 使い方:
+ *   node build-paperback-pdf.js
+ *
+ * 依存:
+ *   - Pandoc
+ *   - weasyprint
+ */
+
+const { spawnSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const bookConfig = require('./book-config');
+
+const baseDir = __dirname;
+const outputFileName = `${bookConfig.metadata.title}_paperback.pdf`;
+const combinedMdPath = path.join(baseDir, 'combined-paperback.md');
+const paperbackCssPath = path.join(baseDir, 'paperback-style.css');
+
+/**
+ * ペーパーバック用CSSを生成
+ */
+function createPaperbackCss() {
+  // KDPペーパーバック用設定
+  // トリムサイズ: 5.83 x 8.27 インチ（148 x 210 mm = A5）
+  // KDP要件: 内側0.5インチ、外側0.25インチ以上（151-300ページ）
+  // 安全マージンを追加: 内側0.875インチ、外側0.625インチ
+  const css = `
+@page {
+  size: 5.83in 8.27in;
+  margin: 0.625in 0.625in 0.625in 0.875in; /* 上 右 下 左（ノド側広め） */
+
+  @bottom-center {
+    content: counter(page);
+    font-size: 10pt;
+    color: #666;
+  }
+}
+
+@page :first {
+  @bottom-center {
+    content: none;
+  }
+}
+
+body {
+  font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif;
+  font-size: 11pt;
+  line-height: 1.8;
+  color: #333;
+  text-align: justify;
+  orphans: 2;
+  widows: 2;
+}
+
+h1 {
+  font-size: 20pt;
+  font-weight: bold;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  page-break-before: always;
+  page-break-after: avoid;
+  border-bottom: 2px solid #3182CE;
+  padding-bottom: 0.3em;
+}
+
+h1:first-of-type {
+  page-break-before: avoid;
+}
+
+h2 {
+  font-size: 16pt;
+  font-weight: bold;
+  margin-top: 1.5em;
+  margin-bottom: 0.8em;
+  page-break-after: avoid;
+  color: #1a365d;
+}
+
+h3 {
+  font-size: 13pt;
+  font-weight: bold;
+  margin-top: 1.2em;
+  margin-bottom: 0.6em;
+  page-break-after: avoid;
+}
+
+p {
+  margin: 0.8em 0;
+  text-indent: 1em;
+}
+
+p:first-child,
+h1 + p,
+h2 + p,
+h3 + p,
+blockquote + p,
+pre + p,
+ul + p,
+ol + p {
+  text-indent: 0;
+}
+
+blockquote {
+  margin: 1em 0;
+  padding: 0.8em 1em;
+  background-color: #f7fafc;
+  border-left: 4px solid #3182CE;
+  font-size: 10pt;
+}
+
+pre, code {
+  font-family: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", monospace;
+  font-size: 9pt;
+}
+
+pre {
+  background-color: #1a202c;
+  color: #e2e8f0;
+  padding: 1em;
+  margin: 1em 0;
+  border-radius: 4px;
+  page-break-inside: avoid;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+code {
+  background-color: #edf2f7;
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+}
+
+pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+img {
+  max-width: 85%;
+  height: auto;
+  display: block;
+  margin: 1em auto;
+  page-break-inside: avoid;
+}
+
+table {
+  max-width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
+  font-size: 9pt;
+  page-break-inside: avoid;
+  table-layout: fixed;
+}
+
+th, td {
+  border: 1px solid #cbd5e0;
+  padding: 0.4em;
+  text-align: left;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+th {
+  background-color: #edf2f7;
+  font-weight: bold;
+}
+
+ul, ol {
+  margin: 1em 0;
+  padding-left: 2em;
+}
+
+li {
+  margin: 0.3em 0;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 2em 0;
+}
+
+/* 強調 */
+strong {
+  font-weight: bold;
+  color: #1a365d;
+}
+
+em {
+  font-style: italic;
+}
+
+/* 脚注 */
+.footnote {
+  font-size: 9pt;
+  color: #666;
+}
+
+/* ページ区切り */
+.page-break {
+  page-break-before: always;
+}
+
+/* コラムボックス */
+.column-box {
+  background-color: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 4px;
+  padding: 1em;
+  margin: 1em 0;
+  page-break-inside: avoid;
+}
+
+/* 比較ボックス */
+.comparison-box {
+  margin: 1em 0;
+  page-break-inside: avoid;
+}
+
+.comparison-before,
+.comparison-after {
+  padding: 0.8em;
+  margin: 0.5em 0;
+  border-radius: 4px;
+}
+
+.comparison-before {
+  background-color: #fff5f5;
+  border-left: 4px solid #e53e3e;
+}
+
+.comparison-after {
+  background-color: #f0fff4;
+  border-left: 4px solid #38a169;
+}
+
+.comparison-result {
+  background-color: #ebf8ff;
+  border-left: 4px solid #3182ce;
+  padding: 0.8em;
+  margin: 0.5em 0;
+  border-radius: 4px;
+}
+
+/* 茶話コーナー */
+.break-corner {
+  background-color: #fffaf0;
+  border: 2px solid #DD6B20;
+  border-radius: 8px;
+  padding: 1em;
+  margin: 1.5em 0;
+  page-break-inside: avoid;
+}
+`;
+
+  fs.writeFileSync(paperbackCssPath, css, 'utf8');
+  console.log('  ✓ ペーパーバック用CSSを生成');
+}
+
+/**
+ * Markdownファイルを結合して章番号を付与
+ */
+function combineMarkdownFiles() {
+  // _metadata.md と 00_toc.md を除外
+  const files = bookConfig.files.filter(f => f !== '_metadata.md' && f !== '00_toc.md');
+  let combined = '';
+
+  for (const file of files) {
+    const filePath = path.join(baseDir, file);
+    if (!fs.existsSync(filePath)) {
+      console.warn(`  警告: ファイルが見つかりません: ${file}`);
+      continue;
+    }
+
+    let content = fs.readFileSync(filePath, 'utf8');
+
+    // 画像パスの修正
+    // ../images/ → images/（パート内ファイル用）- 先に長いパターンを置換
+    // ./images/ → images/（ルートファイル用）
+    content = content.replace(/\.\.\/images\//g, 'images/');
+    content = content.replace(/\.\/images\//g, 'images/');
+
+    combined += content + '\n\n';
+  }
+
+  fs.writeFileSync(combinedMdPath, combined, 'utf8');
+  console.log(`  ✓ ${files.length}ファイルを結合`);
+}
+
+/**
+ * 一時ファイルをクリーンアップ
+ */
+function cleanupTempFiles() {
+  if (fs.existsSync(combinedMdPath)) {
+    fs.unlinkSync(combinedMdPath);
+  }
+  if (fs.existsSync(paperbackCssPath)) {
+    fs.unlinkSync(paperbackCssPath);
+  }
+}
+
+/**
+ * Pandocのインストール確認
+ */
+function checkPandocInstalled() {
+  const result = spawnSync('pandoc', ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+/**
+ * weasyprintのインストール確認
+ */
+function checkWeasyprintInstalled() {
+  const result = spawnSync('weasyprint', ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+/**
+ * Pandoc + weasyprint でPDFを生成
+ */
+function generatePdf() {
+  return new Promise((resolve, reject) => {
+    const args = [
+      combinedMdPath,
+      '-o', outputFileName,
+      '--pdf-engine=weasyprint',
+      `--css=${paperbackCssPath}`,
+      '-f', 'gfm',
+      '--metadata', `title=${bookConfig.metadata.title}`
+    ];
+
+    console.log('  Pandocコマンドを実行中...');
+
+    const pandoc = spawn('pandoc', args, {
+      cwd: baseDir,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stderr = '';
+
+    pandoc.stderr.on('data', (data) => {
+      stderr += data.toString();
+      // ERRORのみ表示
+      const lines = data.toString().split('\n');
+      for (const line of lines) {
+        if (line.startsWith('ERROR:')) {
+          process.stderr.write('  ' + line + '\n');
+        }
+      }
+    });
+
+    pandoc.on('error', (error) => {
+      reject(new Error(`Pandocの実行に失敗しました: ${error.message}`));
+    });
+
+    pandoc.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Pandocがエラーで終了しました (exit code: ${code})\n${stderr}`));
+      }
+    });
+  });
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  console.log('='.repeat(60));
+  console.log('ペーパーバック本文PDF生成スクリプト');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('設定:');
+  console.log('  トリムサイズ: 5.83 x 8.27 インチ（A5）');
+  console.log('  マージン: 上下外 0.625インチ、内側（ノド）0.875インチ');
+  console.log('');
+
+  try {
+    // 1. 依存ツールの確認
+    console.log('[1/5] 依存ツールの確認...');
+    if (!checkPandocInstalled()) {
+      throw new Error('Pandocがインストールされていません。\n  macOS: brew install pandoc');
+    }
+    if (!checkWeasyprintInstalled()) {
+      throw new Error('weasyprintがインストールされていません。\n  pip install weasyprint');
+    }
+    console.log('  ✓ Pandoc, weasyprint が見つかりました');
+    console.log('');
+
+    // 2. ペーパーバック用CSSを生成
+    console.log('[2/5] ペーパーバック用CSSを生成...');
+    createPaperbackCss();
+    console.log('');
+
+    // 3. Markdownを結合
+    console.log('[3/5] Markdownファイルを結合...');
+    combineMarkdownFiles();
+    console.log('');
+
+    // 4. PDF生成
+    console.log('[4/5] PDFを生成中...');
+    await generatePdf();
+    console.log('  ✓ PDF生成が完了しました');
+    console.log('');
+
+    // 5. クリーンアップ
+    console.log('[5/5] 一時ファイルをクリーンアップ...');
+    cleanupTempFiles();
+    console.log('  ✓ クリーンアップ完了');
+    console.log('');
+
+    // 結果表示
+    const outputPath = path.join(baseDir, outputFileName);
+    const stats = fs.statSync(outputPath);
+    const fileSizeMB = (stats.size / 1024 / 1024).toFixed(2);
+
+    console.log('='.repeat(60));
+    console.log('生成完了!');
+    console.log('='.repeat(60));
+    console.log(`ファイル: ${outputFileName}`);
+    console.log(`サイズ: ${fileSizeMB} MB`);
+    console.log('');
+    console.log('KDPにアップロード:');
+    console.log('  1. 表紙: images/cover_paperback.pdf');
+    console.log(`  2. 本文: ${outputFileName}`);
+    console.log('');
+
+  } catch (error) {
+    // エラー時もクリーンアップを実行
+    cleanupTempFiles();
+
+    console.error('');
+    console.error('='.repeat(60));
+    console.error('エラーが発生しました');
+    console.error('='.repeat(60));
+    console.error(error.message);
+    console.error('');
+    process.exit(1);
+  }
+}
+
+// スクリプト実行
+main();


### PR DESCRIPTION
## 概要
「AIエージェント開発は仕様が9割」のペーパーバック版に対応するスクリプトを追加。

Closes #178

## 変更内容
### 追加ファイル
- `build-paperback-pdf.js`: ペーパーバック本文PDF生成スクリプト
  - トリムサイズ: 5.83 x 8.27 インチ（A5）
  - マージン: 上下外 0.625in、内側（ノド）0.875in
  - 画像パス自動変換対応

- `build-paperback-cover.js`: 表紙PDF生成スクリプト
  - 表・背・裏表紙を自動生成
  - ページ数から背幅を自動計算
  - バーコード領域確保済み

### 修正ファイル
- `book-config.js`: バージョン更新 (v0.1.0 → v1.0.0)

## 検証結果
- ✅ PDF生成成功（6.66 MB、400ページ）
- ✅ サイズ確認: 5.83" x 8.27"（A5）

## 使用方法
```bash
# 本文PDF生成
node build-paperback-pdf.js

# 表紙PDF生成（ページ数を指定）
node build-paperback-cover.js 400
```

## Test Plan
- [ ] `node build-paperback-pdf.js` でPDF生成
- [ ] `pdfinfo` でサイズ確認（5.83" x 8.27"）
- [ ] KDPプレビューでアップロードテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ペーパーバック形式での出版に対応
  * ペーパーバック用カバー画像の自動生成機能を追加
  * Markdown からペーパーバック PDF の自動生成機能を追加
  * バージョンを 1.0.0 にアップデート

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->