### PR TITLE
feat(book): #223 第12a章にGitHub Copilot Skillsの補足を追加

### DIFF
--- a/books/ai-spec-driven-development-90percent/part4_faq/12a_copilot-agents.md
+++ b/books/ai-spec-driven-development-90percent/part4_faq/12a_copilot-agents.md
@@ -569,7 +569,7 @@ GitHub Copilotのカスタムエージェントは**Premium Requests**を消費�
 
 Skills を使うと、新メンバーもベテランと同じ方法でタスクを実行できます。
 
-### 現時点での制限
+### 現時点での制限（2026年1月時点）
 
 - リポジトリ単位での作成のみ（Organization/Enterprise単位は今後対応予定）
 - Copilot有料プラン（Individual/Business/Enterprise）が必要


### PR DESCRIPTION
## Summary
- Agents vs Skills の違いを表で説明
- Skills でできることを簡潔に紹介
- 現時点での制限事項を記載

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * GitHub Copilot Skillsに関する新しいセクションを追加。AgentsとSkillsの比較、利用可能な機能、および2026年1月時点での制限事項についての詳細説明を記載しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->