### PR TITLE
feat: #229 ペーパーバック用リンク表記の自動変換

### DIFF
--- a/books/ai-spec-driven-development-90percent/build-paperback-pdf.js
+++ b/books/ai-spec-driven-development-90percent/build-paperback-pdf.js
@@ -292,6 +292,12 @@ function combineMarkdownFiles() {
     content = content.replace(/\.\.\/images\//g, 'images/');
     content = content.replace(/\.\/images\//g, 'images/');
 
+    // ペーパーバック用リンク変換（印刷版ではURLクリック不可）
+    // ページ内リンク: [テキスト](#anchor) → テキスト
+    content = content.replace(/\[([^\]]+)\]\(#[^)]+\)/g, '$1');
+    // 外部リンク: [テキスト](https://...) → テキスト（URL）
+    content = content.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '$1（$2）');
+
     combined += content + '\n\n';
   }
 


### PR DESCRIPTION
Closes #229

## Summary
- ペーパーバック本文PDF生成時にMarkdownリンクを印刷向けの表記に自動変換
- 外部リンク: `[テキスト](URL)` → `テキスト（URL）`
- ページ内リンク: `[テキスト](#anchor)` → `テキスト`
- 元のMarkdownファイルは変更しないため、EPUB/Kindle版への影響なし

## Test Plan
- [ ] `node build-paperback-pdf.js` でPDF生成が成功すること
- [ ] 生成PDFでリンク箇所がURL併記になっていること
- [ ] EPUB版に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ペーパーバック PDF 生成時のリンク処理を改善。内部ページリンクはテキストに変換され、外部リンクはテキストと URL の形式で表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->