### PR TITLE
fix: MCPサーバーのパス不整合を修正

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -32,14 +32,14 @@ npm install
 ```bash
 npm run check
 # または
-node index.mjs --check
+node dist/index.js --check
 ```
 
 3) MCPクライアントから起動（推奨）
 - このサーバーは標準入出力（stdio）で動作し、MCP対応クライアントから起動されます。
 - 設定例（外部MCPサーバーの登録）:
   - Command: `node`
-  - Args: `/absolute/path/to/ai-spec-driven-development/mcp/index.mjs`
+  - Args: `/absolute/path/to/ai-spec-driven-development/mcp/dist/index.js`
   - Working Directory: `/absolute/path/to/ai-spec-driven-development/mcp`
 - 例: Claude Code (VS Code) / Claude Desktop / MCP対応クライアントで上記を登録してください。
 
@@ -48,7 +48,7 @@ node index.mjs --check
 ```bash
 npm start
 # または
-node index.mjs
+node dist/index.js
 ```
 
 - 標準入出力で待機します（HTTPサーバーではありません）。停止は Ctrl+C。
@@ -59,7 +59,7 @@ node index.mjs
 This server is intended to run as an MCP over stdio, launched by an MCP-capable client (e.g., Claude Desktop, VS Code MCP clients). To validate locally:
 
 ```bash
-node index.mjs --check
+node dist/index.js --check
 ```
 
 This will parse and build the in-memory index without opening stdio.
@@ -72,7 +72,7 @@ npm run check
 
 ## Configure in an MCP client
 
-- Command: `node /absolute/path/to/ai-spec-driven-development/mcp/index.mjs`
+- Command: `node /absolute/path/to/ai-spec-driven-development/mcp/dist/index.js`
 - Working directory: repository root or `mcp/`
 
 The server will expose:
@@ -89,7 +89,7 @@ The server will expose:
 
 - Add an external MCP server in the extension settings:
   - Command: `node`
-  - Args: `/absolute/path/to/ai-spec-driven-development/mcp/index.mjs`
+  - Args: `/absolute/path/to/ai-spec-driven-development/mcp/dist/index.js`
   - Working Directory: `/absolute/path/to/ai-spec-driven-development/mcp`
 - Open this repository and verify Prompts/Tools/Resources are listed.
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -42,8 +42,9 @@ const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DOCS_ROOT = path.join(REPO_ROOT, 'docs');
+const DOCS_TEMPLATE_ROOT = path.join(REPO_ROOT, 'docs-template');
 const SPECS_DIR = path.join(DOCS_ROOT, 'specs');
-const GLOSSARY_PATH = path.join(DOCS_ROOT, '06-reference', 'GLOSSARY.md');
+const GLOSSARY_PATH = path.join(DOCS_TEMPLATE_ROOT, '06-reference', 'GLOSSARY.md');
 
 // ---------- FS helpers ----------
 const readFileSafe = (p: string): string => { try { return fs.readFileSync(p, 'utf-8'); } catch { return ''; } };
@@ -74,7 +75,7 @@ const splitSections = (markdown: string): SectionIndexEntry[] => {
 };
 
 // ---------- Build indexes ----------
-const MD_FILES = [path.join(REPO_ROOT, 'README.md'), path.join(REPO_ROOT, 'ai_spec_driven_development.md'), ...listMarkdown(DOCS_ROOT)].filter(f => fs.existsSync(f));
+const MD_FILES = [path.join(REPO_ROOT, 'README.md'), path.join(REPO_ROOT, 'ai_spec_driven_development.md'), ...listMarkdown(DOCS_ROOT), ...listMarkdown(DOCS_TEMPLATE_ROOT)].filter(f => fs.existsSync(f));
 const buildSearchIndex = (files: string[]): SectionIndexEntry[] => files.flatMap(f => {
   const rel = path.relative(REPO_ROOT, f);
   const text = readFileSafe(f);


### PR DESCRIPTION
## Summary
- `DOCS_TEMPLATE_ROOT` 追加: `docs-template/` もインデックス対象に（7→69ファイル）
- `GLOSSARY_PATH` 修正: `docs-template/06-reference/GLOSSARY.md` を参照（0→98用語）
- `README.md`: エントリポイントを `index.mjs` → `dist/index.js` に統一

Closes #262

## Test plan
- [x] `npm run build` 成功
- [x] `npm run check` 出力: `files=69 sections=944 specs=2 errors=0 glossaryTerms=98`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * MCPサーバー実行手順のドキュメント更新
  
* **チューニング**
  * ドキュメント テンプレート機能への対応を追加し、複数のドキュメント ソースをサポート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->