### PR TITLE
feat: #284 7文書テンプレートに Frontmatter・Changelog・バージョニングルールを追加

### DIFF
--- a/docs-template/01-context/PROJECT.md
+++ b/docs-template/01-context/PROJECT.md
@@ -2,7 +2,7 @@
 title: "PROJECT"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---
@@ -15,10 +15,12 @@ updated: "YYYY-MM-DD"
 [プロジェクト名]
 
 ### バージョン
-1.0.0
+
+Frontmatter の `version` を参照
 
 ### 最終更新日
-[YYYY-MM-DD]
+
+Frontmatter の `updated` を参照
 
 ## 2. プロジェクトビジョン
 

--- a/docs-template/02-design/ARCHITECTURE.md
+++ b/docs-template/02-design/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 title: "ARCHITECTURE"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---

--- a/docs-template/02-design/DOMAIN.md
+++ b/docs-template/02-design/DOMAIN.md
@@ -2,7 +2,7 @@
 title: "DOMAIN"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---

--- a/docs-template/03-implementation/PATTERNS.md
+++ b/docs-template/03-implementation/PATTERNS.md
@@ -2,7 +2,7 @@
 title: "PATTERNS"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---

--- a/docs-template/04-quality/TESTING.md
+++ b/docs-template/04-quality/TESTING.md
@@ -2,7 +2,7 @@
 title: "TESTING"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---

--- a/docs-template/05-operations/DEPLOYMENT.md
+++ b/docs-template/05-operations/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 title: "DEPLOYMENT"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---
@@ -235,4 +235,4 @@ PRマージ後のブランチ切り替え忘れを防ぐため、セッション
 
 #### 追加
 
-- 初版作成
+- 初版作成（旧「ドキュメント更新履歴」セクションを Changelog 形式に移行）

--- a/docs-template/MASTER.md
+++ b/docs-template/MASTER.md
@@ -2,7 +2,7 @@
 title: "MASTER"
 version: "1.0.0"
 status: "draft"
-owner: ""
+owner: "@your-github-handle"
 created: "YYYY-MM-DD"
 updated: "YYYY-MM-DD"
 ---
@@ -135,9 +135,9 @@ AIが生成したドキュメント・コードは、以下のタイミングで
 
 ## プロジェクト識別情報
 - **プロジェクト名**: [プロジェクト名を入力]
-- **バージョン**: 1.0.0
+- **バージョン**: Frontmatter の `version` を参照
 - **使用AIツール**: Claude Code, GitHub Copilot, Cursor
-- **最終更新日**: 2025-07-28
+- **最終更新日**: Frontmatter の `updated` を参照
 
 ## プロジェクト概要
 [30秒で理解できるプロジェクトの説明を記載]
@@ -551,7 +551,9 @@ AI: DEPLOYMENT.md（索引）→ deployment/self-review.md を読み込み
 
 ### Frontmatter
 
-7文書全てに以下の YAML Frontmatter を付与する。Frontmatter が文書のメタデータの正式なソースとなる。
+コア7文書（MASTER/PROJECT/ARCHITECTURE/DOMAIN/PATTERNS/TESTING/DEPLOYMENT）に以下の YAML Frontmatter を付与する。Frontmatter が文書のメタデータの正式なソースとなる。
+
+> **注**: `docs/specs/` 配下の仕様ファイルには Spec Kit 運用ガイドの Front Matter スキーマ（6ステータス: draft/review/approved/implementing/done/deprecated）を適用すること。本ルールはコア7文書専用。
 
 必須フィールド:
 
@@ -559,7 +561,7 @@ AI: DEPLOYMENT.md（索引）→ deployment/self-review.md を読み込み
 |-----------|------|-----|
 | title | 文書タイトル | ARCHITECTURE |
 | version | セマンティックバージョン | 1.2.0 |
-| status | 文書の状態 | draft / review / approved |
+| status | 文書の状態（有効値: `draft`, `review`, `approved`） | draft |
 | owner | 責任者 | @username |
 | created | 作成日 | 2026-01-01 |
 | updated | 最終更新日 | 2026-01-15 |
@@ -587,7 +589,7 @@ draft → review → approved
 | review | レビュー中 | ほぼ確定だが変更の可能性あり |
 | approved | 承認済み | 正式な仕様として遵守 |
 
-1週間レビューコメントがなければ `approved` に昇格する。
+`review` ステータスの文書に対し1週間レビューコメントがなければ、ドキュメントオーナーが `approved` に昇格する。
 
 ### バージョニングルール
 
@@ -599,7 +601,20 @@ draft → review → approved
 | MEDIUM | 項目追加、既存概念の拡張 | マイナー（0.x.0） |
 | HIGH | 構造変更、概念の再定義・削除 | メジャー（x.0.0） |
 
-変更時は Frontmatter の `version`、`updated`、`changeImpact` を同時に更新し、末尾の Changelog セクションにエントリを追加すること。
+変更時は Frontmatter の `version`、`updated`、`changeImpact` を同時に更新し、末尾の Changelog セクションにエントリを追加すること。`changeImpact` は初版では省略可。初回変更時に Frontmatter へ追加する。
+
+### Changelog カテゴリ
+
+Changelog エントリには以下のカテゴリを使用する（[Keep a Changelog](https://keepachangelog.com/) 準拠）。
+
+| カテゴリ | 用途 |
+|---------|------|
+| 追加 | 新機能・新項目 |
+| 変更 | 既存機能の変更 |
+| 非推奨 | 将来削除予定の機能 |
+| 削除 | 削除された機能 |
+| 修正 | バグ修正 |
+| セキュリティ | セキュリティ関連の修正 |
 
 ## コードレビュー チェックリスト（追補）
 


### PR DESCRIPTION
## Summary

- 7文書テンプレート全てに YAML Frontmatter（title, version, status, owner, created, updated）を追加
- MASTER.md に文書運用ルール（ステータスワークフロー・バージョニング・Changelog運用）を追加
- 7文書全てに Changelog セクションを追加
- DEPLOYMENT.md の既存「ドキュメント更新履歴」を標準 Changelog 形式に統一

## Changes

### YAML Frontmatter（全7文書）
```yaml
---
title: "MASTER"
version: "1.0.0"
status: "draft"
owner: ""
created: "YYYY-MM-DD"
updated: "YYYY-MM-DD"
---
```

### 文書運用ルール（MASTER.md に追加）
- **ステータスワークフロー**: draft → review → approved
- **バージョニング**: 影響度ベース SemVer（LOW=patch, MEDIUM=minor, HIGH=major）
- **Changelog 運用**: 各文書末尾に `## Changelog` セクション

### Changelog セクション（全7文書）
- 標準フォーマットで初版エントリを追加

## Self-Review

- [x] markdownlint 0エラー確認済み
- [x] Husky pre-commit フック通過確認
- [x] 全7文書の Frontmatter 追加確認
- [x] 全7文書の Changelog セクション追加確認
- [x] MASTER.md の運用ルール追記確認

## Test plan

- [ ] `npx markdownlint-cli2 "docs-template/**/*.md"` で 0 エラーを確認
- [ ] 各テンプレートの Frontmatter が正しい YAML 形式であることを確認
- [ ] MASTER.md の文書運用ルールセクションの内容が書籍と一致していることを確認

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * すべてのテンプレートに統一されたフロントマターを追加し、メタデータで版情報と編集履歴を管理可能に
  * 各ドキュメント末尾に Changelog（1.0.0 の初版記録）を導入
  * 品質指標の項目を追記（定性的指標の拡張）
  * ドキュメント運用ルールを整備し、ガバナンスとバージョニング規則を明文化（一部重複を含む）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->