### PR TITLE
docs: #297 ツール横断コンテキスト管理比較を追加

### DIFF
--- a/docs/CLAUDE_CODE_COMMANDS_SKILLS.md
+++ b/docs/CLAUDE_CODE_COMMANDS_SKILLS.md
@@ -241,7 +241,7 @@ GitHub Copilot には複数の拡張方式があり、コンテキスト隔離�
 | --- | --- | --- | --- |
 | Skills（`.github/skills/`） | **メイン内**（共有） | AI が自動判断 | コーディング規約、テストパターン |
 | @workspace / @vscode | **メイン内**（共有） | `@` メンション | ファイル検索、IDE操作 |
-| Subagents | **隔離** | AI が自動委任 | 重い調査・分析タスク |
+| Subagents | **隔離** | ユーザーがプロンプトで指示（自動委任も可能） | 重い調査・分析タスク |
 | Coding Agent | **完全隔離**（GitHub Actions） | Issue 割り当て | 自律的なPR作成 |
 | Extensions | **外部プロセス**（HTTP/SSE） | `@extension名` | 外部サービス連携 |
 
@@ -249,34 +249,36 @@ GitHub Copilot には複数の拡張方式があり、コンテキスト隔離�
 
 | 概念 | Claude Code | GitHub Copilot | 備考 |
 | --- | --- | --- | --- |
-| メイン内・手動呼出 | Commands（`.claude/commands/`） | なし（相当機能なし） | Copilot は手動呼出コマンドを持たない |
+| メイン内・手動呼出（カスタム定義） | Commands（`.claude/commands/`） | なし（ユーザー定義非対応） | Copilot は組込みスラッシュコマンドはあるが、ユーザー定義プロンプトテンプレートは非対応 |
 | メイン内・自動起動 | Skills（`.claude/skills/`） | Skills（`.github/skills/`） | 同一標準（agentskills.io） |
 | 隔離コンテキスト | Task ツール（サブエージェント） | Subagents | どちらもサマリーのみ返却 |
 | 自律コーディング | Agent mode | Coding Agent | Copilot は GitHub Actions 上で実行 |
-| コンテキスト上限 | 200K+ tokens | 64K〜128K tokens | Copilot はモデル・エディタで変動 |
+| コンテキスト上限 | 200K+ tokens | 64K〜128K tokens（2025年12月時点、GPT-4o 基準） | Copilot は複数モデル対応のため上限が異なる |
 
 ### 5.3 Agent Skills オープンスタンダード
 
-Claude Code Skills と GitHub Copilot Skills は **agentskills.io** という共通のオープンスタンダードに基づいている。Anthropic、GitHub（Microsoft）、OpenAI、Cursor、Figma 等が共同策定した仕様であり、`.github/skills/SKILL.md` の形式で定義する。
+Claude Code Skills と GitHub Copilot Skills は **agentskills.io** という共通のオープンスタンダードに基づいている。Anthropic が開発・公開した仕様であり、GitHub（Microsoft）、OpenAI、Cursor、Figma 等の主要ツールが採用している。`.github/skills/SKILL.md` の形式で定義する。
 
 Agent Skills の特徴:
 
-- **Progressive Disclosure**: Level 1（メタデータ読み込み）→ Level 2（本文注入）→ Level 3（追加リソースアクセス）の3段階
+- **Progressive Disclosure**: Metadata（~100 tokens）→ Instructions（<5,000 tokens 推奨）→ Resources（必要時のみ）の3段階
 - **自動トリガー**: `description` フィールドに基づいて AI が関連性を判断し、自動的に読み込む
 - **クロスツール互換**: 1つのスキル定義が Claude Code、Copilot、Cursor で利用可能
 
 ### 5.4 Copilot Skills の現状と信頼性
 
+> 以下の情報は 2026年2月時点のものであり、最新状況は公式ドキュメントを参照してください。
+
 | 項目 | 状態 |
 | --- | --- |
-| 仕様公開 | 2025年12月18日（Public Preview） |
+| 仕様公開 | 2025年12月18日（Coding Agent / CLI 向け GA） |
 | VS Code Insiders | 動作する |
-| VS Code Stable | 対応中 |
-| CLI | バグあり（Skills が読み込まれない報告: Issue #1080） |
+| VS Code Stable | 対応中（2025年1月以降順次対応） |
+| CLI | 安定化途中（初期に Skills 読み込みバグの報告あり） |
 | GitHub.com Web | 非対応 |
 | 依存関係バリデーション | 未実装 |
 
-**推奨**: 個人プロジェクトでの活用は可能だが、チーム必須ワークフローへの組み込みは CLI の安定化を待つのが安全。
+**推奨**: 個人プロジェクトでの活用は可能だが、チーム必須ワークフローへの組み込みはエディタ・CLI の安定化状況を確認してから行うのが安全。
 
 ### 5.5 コンテキスト管理の共通原則
 
@@ -347,7 +349,7 @@ Agent Skills の特徴:
 
 ### 外部リファレンス
 
-- [Agent Skills Specification](https://agentskills.io/specification) - Anthropic/GitHub/Microsoft 共同策定のオープンスタンダード
+- [Agent Skills Specification](https://agentskills.io/specification) - Anthropic が開発・公開したオープンスタンダード
 - [About Agent Skills - GitHub Docs](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) - Copilot Skills 公式ドキュメント
 - [Subagents in VS Code](https://code.visualstudio.com/docs/copilot/agents/subagents) - Copilot Subagents の解説
 - [About Coding Agent - GitHub Docs](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-coding-agent) - 自律型コーディングエージェント


### PR DESCRIPTION
## Summary

- `docs/CLAUDE_CODE_COMMANDS_SKILLS.md` を Claude Code 固有のガイドからツール横断的なコンテキスト管理ガイドに拡張
- GitHub Copilot Skills / Subagents / Coding Agent との比較セクションを追加
- Agent Skills オープンスタンダード（agentskills.io）の紹介を追加

## 変更内容

| 変更箇所 | 内容 |
| --- | --- |
| Frontmatter | id・title・tags をツール横断的に更新 |
| はじめに | ツール共通の原則として再構成 |
| 新セクション5 | 他ツールとのコンテキスト管理比較（5.1〜5.5） |
| セクション6-7 | 番号振り直し（旧5→6、旧6→7） |
| 参考資料 | Copilot 公式ドキュメント4件を追加 |

## 新セクション5の構成

- 5.1 GitHub Copilot の拡張機能マップ（Skills / Subagents / Coding Agent / Extensions）
- 5.2 ツール横断比較テーブル（Claude Code vs Copilot）
- 5.3 Agent Skills オープンスタンダード（agentskills.io）
- 5.4 Copilot Skills の現状と信頼性（Public Preview、CLI バグ報告あり）
- 5.5 コンテキスト管理の共通原則

## 行数

280行 → 353行（500行ソフトリミット内）

## Test plan

- [x] markdownlint エラーなし（0 errors）
- [x] Husky pre-commit hook 通過
- [ ] 既存セクション（1-4）の内容が壊れていないか確認
- [ ] 新セクション5のテーブルが正しく表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * AI開発ツール全般のコンテキスト管理に関するガイドを大幅に拡張しました（メタデータ更新・範囲拡大）。
  * 他ツール（GitHub Copilot、Cursor等）との比較表と図を追加し、実装・並列化・トークン利用の差異を可視化しました。
  * エージェントスキル／オープン標準に関する解説と実践的判断ロジック（コマンド vs スキルの選択基準等）を追加しました。
  * セクション構成を再編成し、参考文献や実装例を充実させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->