### PR TITLE
feat: #318 Multi-CLI Review 知見の体系化（ACE Playbook + Discussion）

### DIFF
--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -1,11 +1,11 @@
 ---
 title: "PLAYBOOK"
-version: "1.0.0"
-status: "draft"
-created: "YYYY-MM-DD"
-updated: "YYYY-MM-DD"
-owner: "@your-github-handle"
-ace_entry_count: 0
+version: "1.1.0"
+status: "active"
+created: "2026-03-10"
+updated: "2026-03-10"
+owner: "@fffokazaki"
+ace_entry_count: 3
 tags: [ace, playbook, knowledge-management]
 references:
   - docs/ACE_FRAMEWORK.md
@@ -168,11 +168,72 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 **Action**: 一覧取得時は `include` オプションで関連を一括取得する。`findMany({ include: { organization: true } })`
 -->
 
-（まだエントリはありません。最初の ACE サイクル実行後にここにエントリが追記されます。）
+### ACE-001: クロスモデルレビューは単一AIモデルでは検出できない問題を発見する
+
+| フィールド | 値 |
+|-----------|---|
+| Category | process |
+| Origin | PR #316 / PR #319 |
+| Date | 2026-03-10 |
+| Helpful | 0 |
+| Harmful | 0 |
+| Status | active |
+
+**Insight**: 異なるAIモデル（Claude/Codex/Gemini/CodeRabbit）は異なるカテゴリの問題を検出する。単一モデルのレビューでは見落とされる問題が、クロスモデルレビューで発見される。
+
+**Context**: PR #316（ドキュメント）では Claude がリンク切れ、Codex が実行可能性、Gemini Bot がパッケージスコープ、CodeRabbit が公式数値不一致を検出。PR #319（スクリプト）では Codex が CRITICAL_BLOCK 誤検出バグを発見し、Claude の silent-failure-hunter が stderr 握りつぶし問題を検出。いずれも単一モデルでは検出されなかった。
+
+**Action**: PR作成前のセルフレビューでは、`pr-review-toolkit`（Claude系サブエージェント）と `codex review --base develop`（GPT系クロスモデル）の両方を実行する。Bot系レビュー（Gemini Code Assist, CodeRabbit）がある場合はその指摘も確認する。
+
+---
+
+### ACE-002: CLIフラグは実機の --help 出力と照合が必須
+
+| フィールド | 値 |
+|-----------|---|
+| Category | tooling |
+| Origin | PR #316 / Issue #315 |
+| Date | 2026-03-10 |
+| Helpful | 0 |
+| Harmful | 0 |
+| Status | active |
+
+**Insight**: Web検索やAI生成の情報だけでは CLI フラグの正確性は保証されない。`codex -p` は存在せず `codex exec` が正解、Copilot `-s` は sandbox ではなく `--silent`、Cursor `-p` は boolean フラグでプロンプトは positional 引数など、実機確認しなければ分からない差異が多い。
+
+**Context**: Multi-CLI Review ドキュメント作成時に5つのAI CLIのフラグを調査。Web検索とAI生成の情報を信じてドキュメント化したが、セルフレビューと実機テストで複数の誤りが発覚。特に Codex CLI は `-p` フラグが存在しないにもかかわらず、Web上の古い情報では `-p` が使われていた。
+
+**Action**: CLI ツールのフラグを記述する際は、(1) `command --help` で実機確認、(2) 公式リポジトリの README/docs と照合、(3) 可能なら `--dry-run` 等で動作確認、の3ステップを必ず実施する。
+
+---
+
+### ACE-003: bash スクリプトは macOS デフォルト環境（bash 3.2）でテストする
+
+| フィールド | 値 |
+|-----------|---|
+| Category | devops |
+| Origin | PR #319 / Issue #317 |
+| Date | 2026-03-10 |
+| Helpful | 0 |
+| Harmful | 0 |
+| Status | active |
+
+**Insight**: macOS のデフォルト bash は 3.2（GPLv2 ライセンス制約）であり、`declare -A`（連想配列）、`head -n -1`（GNU拡張）、`timeout` コマンドなどが使えない。CI環境（Linux, bash 5.x）では動くが macOS では動かないスクリプトが生まれやすい。
+
+**Context**: `multi-review.sh` を連想配列ベースで実装したところ、macOS の bash 3.2 で `declare -A: invalid option` エラーが発生。関数ベースのルックアップに書き直し、`head -n -1` を `sed` に変更、`timeout` を kill ベースフォールバックに変更して解決。
+
+**Action**: bash スクリプトの移植性を確保するには、(1) 連想配列の代わりに case 文/関数ルックアップを使用、(2) GNU 拡張コマンドには POSIX 互換フォールバックを用意、(3) macOS のデフォルト環境で `--dry-run` テストを実施する。shebang は `#!/usr/bin/env bash` のまま、bash 3.2+ 互換コードを書く。
 
 ---
 
 ## Changelog
+
+### [1.1.0] - 2026-03-10
+
+#### 追加
+- ACE-001: クロスモデルレビューの検出パターン差異
+- ACE-002: CLIフラグの実機確認必須ルール
+- ACE-003: bash 3.2 macOS互換性の知見
+- GitHub Discussion #320 にナラティブ版を投稿
 
 ### [1.0.0] - YYYY-MM-DD
 

--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -1,7 +1,7 @@
 ---
 title: "PLAYBOOK"
 version: "1.1.0"
-status: "active"
+status: "approved"
 created: "2026-03-10"
 updated: "2026-03-10"
 owner: "@fffokazaki"

--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -181,7 +181,7 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 **Insight**: 異なるAIモデル（Claude/Codex/Gemini/CodeRabbit）は異なるカテゴリの問題を検出する。単一モデルのレビューでは見落とされる問題が、クロスモデルレビューで発見される。
 
-**Context**: PR #316（ドキュメント）では Claude がリンク切れ、Codex が実行可能性、Gemini Bot がパッケージスコープ、CodeRabbit が公式数値不一致を検出。PR #319（スクリプト）では Codex が CRITICAL_BLOCK 誤検出バグを発見し、Claude の silent-failure-hunter が stderr 握りつぶし問題を検出。いずれも単一モデルでは検出されなかった。
+**Context**: PR #316（ドキュメント）では Claude がnpmパッケージ名の間違いと壊れたリンク、Codex がスクリプト未実装注記の不足、Gemini Bot がパッケージスコープの間違いと無料枠数値の不一致、CodeRabbit が未実装スクリプトの注記不足を検出。PR #319（スクリプト）では Codex が CRITICAL_BLOCK 誤検出バグを発見し、Claude の pr-review-toolkit（code-reviewer + silent-failure-hunter）が stderr 握りつぶし・サイレントフォールバック・空結果の偽成功を検出。いずれも単一モデルでは検出されなかった。
 
 **Action**: PR作成前のセルフレビューでは、`pr-review-toolkit`（Claude系サブエージェント）と `codex review --base develop`（GPT系クロスモデル）の両方を実行する。Bot系レビュー（Gemini Code Assist, CodeRabbit）がある場合はその指摘も確認する。
 
@@ -217,7 +217,7 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 | Harmful | 0 |
 | Status | active |
 
-**Insight**: macOS のデフォルト bash は 3.2（GPLv2 ライセンス制約）であり、`declare -A`（連想配列）、`head -n -1`（GNU拡張）、`timeout` コマンドなどが使えない。CI環境（Linux, bash 5.x）では動くが macOS では動かないスクリプトが生まれやすい。
+**Insight**: macOS のデフォルト bash は 3.2（bash 4.0+ が GPLv3 に移行したため Apple が更新を停止）であり、`declare -A`（連想配列）、`head -n -1`（GNU拡張）、`timeout` コマンドなどが使えない。CI環境（Linux, bash 5.x）では動くが macOS では動かないスクリプトが生まれやすい。
 
 **Context**: `multi-review.sh` を連想配列ベースで実装したところ、macOS の bash 3.2 で `declare -A: invalid option` エラーが発生。関数ベースのルックアップに書き直し、`head -n -1` を `sed` に変更、`timeout` を kill ベースフォールバックに変更して解決。
 


### PR DESCRIPTION
Closes #318

## Summary
- ACE Playbook に3エントリを追記（ACE-001〜003）
  - ACE-001: クロスモデルレビューの検出パターン差異（process）
  - ACE-002: CLIフラグの実機確認必須ルール（tooling）
  - ACE-003: bash 3.2 macOS互換性の知見（devops）
- GitHub Discussion #320 にナラティブ版の知見を投稿済み
- Frontmatter 更新（version 1.1.0, ace_entry_count: 3）

## Self-Review
- pr-review-toolkit (comment-analyzer + code-reviewer) 実施
- comment-analyzer の指摘3点を修正（各モデル検出内容の帰属精密化、GPLv3ライセンス説明修正）
- Codex CLI review はタイムアウト（ドキュメントのみの変更のため影響なし）

## Test Plan
- [ ] PLAYBOOK.md のエントリフォーマットがテンプレートに準拠していること
- [ ] Frontmatter の ace_entry_count が実エントリ数と一致すること
- [ ] Changelog が正しく更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)