### PR TITLE
fix: #322 yq // empty を // "" に修正（mikefarah/yq v4 互換）

### DIFF
--- a/scripts/multi-review.sh
+++ b/scripts/multi-review.sh
@@ -179,20 +179,20 @@ load_config() {
     fi
 
     local cfg_val
-    cfg_val=$(yq -r '.mode // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    cfg_val=$(yq -r '.mode // ""' "$CONFIG_FILE" 2>/dev/null || true)
     [[ -n "$cfg_val" ]] && MODE="$cfg_val"
 
-    cfg_val=$(yq -r '.parallel // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    cfg_val=$(yq -r '.parallel // ""' "$CONFIG_FILE" 2>/dev/null || true)
     [[ "$cfg_val" == "true" ]] && PARALLEL=true
     [[ "$cfg_val" == "false" ]] && PARALLEL=false
 
-    cfg_val=$(yq -r '.cost_strategy // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    cfg_val=$(yq -r '.cost_strategy // ""' "$CONFIG_FILE" 2>/dev/null || true)
     [[ -n "$cfg_val" ]] && STRATEGY="$cfg_val"
 
-    cfg_val=$(yq -r '.timeout // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    cfg_val=$(yq -r '.timeout // ""' "$CONFIG_FILE" 2>/dev/null || true)
     [[ -n "$cfg_val" ]] && TIMEOUT="$cfg_val"
 
-    cfg_val=$(yq -r '.output_dir // empty' "$CONFIG_FILE" 2>/dev/null || true)
+    cfg_val=$(yq -r '.output_dir // ""' "$CONFIG_FILE" 2>/dev/null || true)
     [[ -n "$cfg_val" ]] && OUTPUT_DIR="${REPO_ROOT}/${cfg_val}"
   else
     echo "ℹ️  yq not found — using defaults. Install yq for config file support." >&2


### PR DESCRIPTION
Closes #322

## Summary
- `scripts/multi-review.sh` の `load_config` で使用していた `yq -r '.key // empty'` を `// ""` に修正
- mikefarah/yq v4 では `// empty` が `lexer: invalid input text "empty"` エラーになる
- `2>/dev/null || true` でサイレント失敗していたため、設定ファイルが読み込まれずデフォルト値で動作していた

## 変更箇所
5箇所の `// empty` → `// ""` 置換（mode, parallel, cost_strategy, timeout, output_dir）

## Test Plan
- [ ] `bash scripts/multi-review.sh --dry-run` で設定値が正しく反映されること
- [ ] `bash scripts/multi-review.sh --help` が正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部スクリプトの設定処理に関する小規模な最適化調整を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->