### PR TITLE
feat: #335 Gemini / Cursor レビュースクリプト追加で5CLI統一

### DIFF
--- a/.github/agents/review-router.agent.md
+++ b/.github/agents/review-router.agent.md
@@ -31,6 +31,8 @@ Copilot CLI を活用し、各レビュースキルを**独立したLLMセッシ
   # または他の CLI で実行:
   → run_in_terminal: bash scripts/codex-review.sh [--staged|--branch]
   → run_in_terminal: bash scripts/copilot-review.sh [--staged|--branch]
+  → run_in_terminal: bash scripts/gemini-review.sh [--staged|--branch]
+  → run_in_terminal: bash scripts/cursor-review.sh [--staged|--branch]
 ```
 
 ### モード2: 動的読み込み（フォールバック）
@@ -69,7 +71,9 @@ scripts/
 ├── review-prompts.sh                ← 5レビュアーのプロンプトテンプレート
 ├── claude-review.sh                 ← Claude Code CLI で実行
 ├── codex-review.sh                  ← Codex CLI で実行
-└── copilot-review.sh                ← Copilot CLI で実行
+├── copilot-review.sh                ← Copilot CLI で実行
+├── gemini-review.sh                 ← Gemini CLI で実行
+└── cursor-review.sh                 ← Cursor CLI で実行
 ```
 
 ## ワークフロー
@@ -86,6 +90,8 @@ scripts/
    - Claude CLI: `bash scripts/claude-review.sh --branch`
    - Codex CLI: `bash scripts/codex-review.sh --branch`
    - Copilot CLI: `bash scripts/copilot-review.sh --branch`
+   - Gemini CLI: `bash scripts/gemini-review.sh --branch`
+   - Cursor CLI: `bash scripts/cursor-review.sh --branch`
    - 全CLI: 上記を順次またはバックグラウンドで実行
 2. スクリプト完了後、結果テーブルと詳細レポートが端末に表示される
 3. 統合結果をユーザーに報告する

--- a/scripts/cursor-review.sh
+++ b/scripts/cursor-review.sh
@@ -40,19 +40,27 @@ fi
 CURSOR_MODEL="${CURSOR_MODEL:-auto}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
 
+# Resolve timeout command (GNU timeout or macOS gtimeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+fi
+
 # Define CLI invocation (called by run_all_reviewers)
 # Note: timeout is mandatory due to known hanging issue with cursor-agent --print
 invoke_cli() {
     local prompt=$1
     local output=$2
 
-    if command -v timeout &>/dev/null; then
-        timeout "$REVIEW_TIMEOUT_SEC" cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
             < "$DIFF_FILE" > "$output" 2>&1
     else
-        echo -e "${YELLOW}Warning: 'timeout' command not found. cursor-agent may hang without it!${NC}" >&2
-        cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
-            < "$DIFF_FILE" > "$output" 2>&1
+        echo -e "${RED}ERROR: 'timeout' command not found. cursor-agent requires timeout protection due to known hanging issue.${NC}" >&2
+        echo -e "${YELLOW}Install coreutils: brew install coreutils${NC}" >&2
+        return 1
     fi
 }
 

--- a/scripts/cursor-review.sh
+++ b/scripts/cursor-review.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Cursor CLI Automated Review Script
+# Runs specialized reviewers in parallel using cursor-agent --print
+#
+# Env:
+#   SKIP_CURSOR_REVIEW=1             Skip review
+#   CURSOR_MODEL=auto                Override model (default: auto)
+#   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
+#   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
+#
+# Cost tier: Flat-rate ($20/month subscription)
+#
+# ⚠️  Known issue: cursor-agent --print may hang in non-interactive mode.
+#     timeout is mandatory to prevent indefinite blocking.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+for f in "$SCRIPT_DIR/review-prompts.sh" "$SCRIPT_DIR/review-common.sh"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: Required file not found: $f" >&2
+        exit 1
+    fi
+done
+source "$SCRIPT_DIR/review-prompts.sh"
+source "$SCRIPT_DIR/review-common.sh"
+
+if [ "$SKIP_CURSOR_REVIEW" = "1" ]; then
+    echo -e "${YELLOW}Skipping Cursor review (SKIP_CURSOR_REVIEW=1)${NC}"
+    exit 0
+fi
+
+if ! command -v cursor-agent &> /dev/null; then
+    echo -e "${YELLOW}Warning: cursor-agent CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: Install Cursor IDE and enable CLI access${NC}"
+    exit 0
+fi
+
+# Configuration
+CURSOR_MODEL="${CURSOR_MODEL:-auto}"
+REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
+
+# Define CLI invocation (called by run_all_reviewers)
+# Note: timeout is mandatory due to known hanging issue with cursor-agent --print
+invoke_cli() {
+    local prompt=$1
+    local output=$2
+
+    if command -v timeout &>/dev/null; then
+        timeout "$REVIEW_TIMEOUT_SEC" cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
+            < "$DIFF_FILE" > "$output" 2>&1
+    else
+        echo -e "${YELLOW}Warning: 'timeout' command not found. cursor-agent may hang without it!${NC}" >&2
+        cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
+            < "$DIFF_FILE" > "$output" 2>&1
+    fi
+}
+
+# Prepare diff (pass through any mode argument: --staged, --branch)
+prepare_diff "$@"
+rc=$?
+if [ "$rc" -eq 1 ]; then
+    exit 0  # Nothing to review
+elif [ "$rc" -ne 0 ]; then
+    exit 1  # Error
+fi
+
+run_all_reviewers "Cursor Code Review (model: ${CURSOR_MODEL})"
+exit $?

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -36,10 +36,18 @@ fi
 # Configuration
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
 
-# Build model flag (only if GEMINI_MODEL is set)
-GEMINI_MODEL_FLAG=""
+# Build model args array (only if GEMINI_MODEL is set)
+GEMINI_MODEL_ARGS=()
 if [ -n "${GEMINI_MODEL:-}" ]; then
-    GEMINI_MODEL_FLAG="--model $GEMINI_MODEL"
+    GEMINI_MODEL_ARGS=("--model" "$GEMINI_MODEL")
+fi
+
+# Resolve timeout command (GNU timeout or macOS gtimeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
 fi
 
 # Define CLI invocation (called by run_all_reviewers)
@@ -47,14 +55,14 @@ invoke_cli() {
     local prompt=$1
     local output=$2
 
-    if command -v timeout &>/dev/null; then
-        timeout "$REVIEW_TIMEOUT_SEC" gemini -p "$prompt" \
-            --sandbox --output-format text $GEMINI_MODEL_FLAG \
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" gemini -p "$prompt" \
+            --sandbox --output-format text "${GEMINI_MODEL_ARGS[@]}" \
             < "$DIFF_FILE" > "$output" 2>&1
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
         gemini -p "$prompt" \
-            --sandbox --output-format text $GEMINI_MODEL_FLAG \
+            --sandbox --output-format text "${GEMINI_MODEL_ARGS[@]}" \
             < "$DIFF_FILE" > "$output" 2>&1
     fi
 }

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Gemini CLI Automated Review Script
+# Runs specialized reviewers in parallel using gemini -p
+#
+# Env:
+#   SKIP_GEMINI_REVIEW=1             Skip review
+#   GEMINI_MODEL                     Override model (default: Gemini CLI default)
+#   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
+#   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
+#
+# Cost tier: Free-tier (generous free quota)
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+for f in "$SCRIPT_DIR/review-prompts.sh" "$SCRIPT_DIR/review-common.sh"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: Required file not found: $f" >&2
+        exit 1
+    fi
+done
+source "$SCRIPT_DIR/review-prompts.sh"
+source "$SCRIPT_DIR/review-common.sh"
+
+if [ "$SKIP_GEMINI_REVIEW" = "1" ]; then
+    echo -e "${YELLOW}Skipping Gemini review (SKIP_GEMINI_REVIEW=1)${NC}"
+    exit 0
+fi
+
+if ! command -v gemini &> /dev/null; then
+    echo -e "${YELLOW}Warning: gemini CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: npm install -g @google/gemini-cli${NC}"
+    exit 0
+fi
+
+# Configuration
+REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
+
+# Build model flag (only if GEMINI_MODEL is set)
+GEMINI_MODEL_FLAG=""
+if [ -n "${GEMINI_MODEL:-}" ]; then
+    GEMINI_MODEL_FLAG="--model $GEMINI_MODEL"
+fi
+
+# Define CLI invocation (called by run_all_reviewers)
+invoke_cli() {
+    local prompt=$1
+    local output=$2
+
+    if command -v timeout &>/dev/null; then
+        timeout "$REVIEW_TIMEOUT_SEC" gemini -p "$prompt" \
+            --sandbox --output-format text $GEMINI_MODEL_FLAG \
+            < "$DIFF_FILE" > "$output" 2>&1
+    else
+        echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
+        gemini -p "$prompt" \
+            --sandbox --output-format text $GEMINI_MODEL_FLAG \
+            < "$DIFF_FILE" > "$output" 2>&1
+    fi
+}
+
+# Prepare diff (pass through any mode argument: --staged, --branch)
+prepare_diff "$@"
+rc=$?
+if [ "$rc" -eq 1 ]; then
+    exit 0  # Nothing to review
+elif [ "$rc" -ne 0 ]; then
+    exit 1  # Error
+fi
+
+MODEL_DISPLAY="${GEMINI_MODEL:-default}"
+run_all_reviewers "Gemini Code Review (model: ${MODEL_DISPLAY})"
+exit $?


### PR DESCRIPTION
Closes #335

## Summary
- `scripts/gemini-review.sh` 新規追加: Gemini CLI レビューラッパー（`--sandbox`, `--output-format text`）
- `scripts/cursor-review.sh` 新規追加: Cursor CLI レビューラッパー（`--print`, timeout 必須）
- `.github/agents/review-router.agent.md` 更新: ディレクトリ構造・コマンド例に Gemini/Cursor 追加
- 既存 `codex-review.sh` パターンを踏襲、`review-common.sh` / `review-prompts.sh` を共有

## セルフレビュー対応
- **code-reviewer**: `GEMINI_MODEL_FLAG` の unquoted 変数を配列化 (word-splitting 防止)
- **silent-failure-hunter**: `gtimeout` フォールバック追加、cursor-review.sh は timeout 必須化 (hard error)
- **Codex CLI**: P1 (macOS timeout) 修正済み、P2 (`prepare_diff` set-e) はスコープ外 → #336
- スコープ外の改善点は #336 に集約

## Test Plan
- [x] `bash -n` syntax check パス
- [x] `SKIP_GEMINI_REVIEW=1` / `SKIP_CURSOR_REVIEW=1` で graceful skip
- [x] CLI 実行パス（差分なし時の正常終了）
- [ ] Gemini CLI インストール環境での実行テスト
- [ ] Cursor CLI インストール環境での実行テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* GeminiおよびCursorの自動コードレビュー機能をレビュータスクに統合しました。
* 複数のレビューツールを並列実行できるようになり、効率的なレビュープロセスが実現します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->