### PR TITLE
fix: #338 codex-review.sh のデフォルトモデルを gpt-5.4 に更新

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -7,7 +7,7 @@
 #
 # Env:
 #   SKIP_CODEX_REVIEW=1              Skip review
-#   CODEX_MODEL=gpt-5.3-codex        Override model (default: gpt-5.3-codex)
+#   CODEX_MODEL=gpt-5.4        Override model (default: gpt-5.4)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
 
@@ -35,7 +35,7 @@ if ! command -v codex &> /dev/null; then
 fi
 
 # Configuration
-CODEX_MODEL="${CODEX_MODEL:-gpt-5.3-codex}"
+CODEX_MODEL="${CODEX_MODEL:-gpt-5.4}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
 
 # Define CLI invocation (called by run_all_reviewers)


### PR DESCRIPTION
Closes #338

## Summary
- `codex-review.sh` のデフォルトモデルを `gpt-5.3-codex` → `gpt-5.4` に更新
- Codex CLI のデフォルトモデルが `gpt-5.4` に変わったため追従

## Test Plan
- [x] `bash -n` syntax check パス
- [x] 他ファイルに `gpt-5.3-codex` の残留なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部レビューツールで使用されるデフォルトモデルをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->