### PR TITLE
chore: #336 レビュースクリプト群のエラーハンドリング改善

### DIFF
--- a/scripts/claude-review.sh
+++ b/scripts/claude-review.sh
@@ -40,12 +40,12 @@ if [ -n "${CLAUDECODE:-}" ]; then
 fi
 
 if ! command -v claude &> /dev/null; then
-    echo -e "${YELLOW}Warning: claude CLI not found, skipping review${NC}"
-    echo -e "${YELLOW}Install: https://docs.anthropic.com/en/docs/claude-code${NC}"
     if [ "${REQUIRE_CLAUDE_REVIEW:-0}" = "1" ]; then
         echo -e "${RED}ERROR: REQUIRE_CLAUDE_REVIEW=1 but claude not found${NC}" >&2
         exit 2
     fi
+    echo -e "${YELLOW}Warning: claude CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: https://docs.anthropic.com/en/docs/claude-code${NC}"
     exit 0
 fi
 
@@ -53,6 +53,14 @@ fi
 # Configuration
 CLAUDE_MODEL="${CLAUDE_MODEL:-}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
+
+# Resolve timeout command (GNU timeout or macOS gtimeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+fi
 
 # Define CLI invocation (called by run_all_reviewers)
 invoke_cli() {
@@ -66,19 +74,11 @@ invoke_cli() {
         cmd=(claude -p "$prompt" --allowedTools "Read,Grep,Glob")
     fi
 
-    # Resolve timeout command (GNU timeout or macOS gtimeout)
-    local timeout_cmd=""
-    if command -v timeout &>/dev/null; then
-        timeout_cmd="timeout"
-    elif command -v gtimeout &>/dev/null; then
-        timeout_cmd="gtimeout"
-    fi
-
-    if [ -n "$timeout_cmd" ]; then
-        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" "${cmd[@]}" < "$DIFF_FILE" > "$output" 2>&1
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" "${cmd[@]}" < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
-        "${cmd[@]}" < "$DIFF_FILE" > "$output" 2>&1
+        "${cmd[@]}" < "$DIFF_FILE" > "$output"
     fi
 }
 

--- a/scripts/claude-review.sh
+++ b/scripts/claude-review.sh
@@ -4,6 +4,7 @@
 #
 # Env:
 #   SKIP_CLAUDE_REVIEW=1     Skip review
+#   REQUIRE_CLAUDE_REVIEW=1  Hard fail if claude CLI not found (default: soft skip)
 #   CLAUDECODE=<set>         Auto-set by Claude Code; skips CLI review when present
 #   CLAUDE_MODEL=<model>     Override model (default: auto)
 #   REVIEW_BASE_BRANCH=main  Override base branch for --branch mode (default: develop)
@@ -21,6 +22,11 @@ done
 source "$SCRIPT_DIR/review-prompts.sh"
 source "$SCRIPT_DIR/review-common.sh"
 
+if [ "$SKIP_CLAUDE_REVIEW" = "1" ] && [ "${REQUIRE_CLAUDE_REVIEW:-0}" = "1" ]; then
+    echo -e "${RED}ERROR: SKIP_CLAUDE_REVIEW and REQUIRE_CLAUDE_REVIEW cannot both be set${NC}" >&2
+    exit 2
+fi
+
 if [ "$SKIP_CLAUDE_REVIEW" = "1" ]; then
     echo -e "${YELLOW}Skipping Claude review (SKIP_CLAUDE_REVIEW=1)${NC}"
     exit 0
@@ -36,8 +42,13 @@ fi
 if ! command -v claude &> /dev/null; then
     echo -e "${YELLOW}Warning: claude CLI not found, skipping review${NC}"
     echo -e "${YELLOW}Install: https://docs.anthropic.com/en/docs/claude-code${NC}"
+    if [ "${REQUIRE_CLAUDE_REVIEW:-0}" = "1" ]; then
+        echo -e "${RED}ERROR: REQUIRE_CLAUDE_REVIEW=1 but claude not found${NC}" >&2
+        exit 2
+    fi
     exit 0
 fi
+
 
 # Configuration
 CLAUDE_MODEL="${CLAUDE_MODEL:-}"
@@ -55,8 +66,16 @@ invoke_cli() {
         cmd=(claude -p "$prompt" --allowedTools "Read,Grep,Glob")
     fi
 
+    # Resolve timeout command (GNU timeout or macOS gtimeout)
+    local timeout_cmd=""
     if command -v timeout &>/dev/null; then
-        timeout "$REVIEW_TIMEOUT_SEC" "${cmd[@]}" < "$DIFF_FILE" > "$output" 2>&1
+        timeout_cmd="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+    fi
+
+    if [ -n "$timeout_cmd" ]; then
+        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" "${cmd[@]}" < "$DIFF_FILE" > "$output" 2>&1
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
         "${cmd[@]}" < "$DIFF_FILE" > "$output" 2>&1
@@ -64,8 +83,8 @@ invoke_cli() {
 }
 
 # Prepare diff (pass through any mode argument: --staged, --branch)
-prepare_diff "$@"
-rc=$?
+rc=0
+prepare_diff "$@" || rc=$?
 if [ "$rc" -eq 1 ]; then
     exit 0  # Nothing to review
 elif [ "$rc" -ne 0 ]; then

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -35,12 +35,12 @@ if [ "$SKIP_CODEX_REVIEW" = "1" ]; then
 fi
 
 if ! command -v codex &> /dev/null; then
-    echo -e "${YELLOW}Warning: codex CLI not found, skipping review${NC}"
-    echo -e "${YELLOW}Install: https://developers.openai.com/codex/cli/${NC}"
     if [ "${REQUIRE_CODEX_REVIEW:-0}" = "1" ]; then
         echo -e "${RED}ERROR: REQUIRE_CODEX_REVIEW=1 but codex not found${NC}" >&2
         exit 2
     fi
+    echo -e "${YELLOW}Warning: codex CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: https://developers.openai.com/codex/cli/${NC}"
     exit 0
 fi
 
@@ -49,26 +49,26 @@ fi
 CODEX_MODEL="${CODEX_MODEL:-gpt-5.4}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
 
+# Resolve timeout command (GNU timeout or macOS gtimeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+fi
+
 # Define CLI invocation (called by run_all_reviewers)
 invoke_cli() {
     local prompt=$1
     local output=$2
 
-    # Resolve timeout command (GNU timeout or macOS gtimeout)
-    local timeout_cmd=""
-    if command -v timeout &>/dev/null; then
-        timeout_cmd="timeout"
-    elif command -v gtimeout &>/dev/null; then
-        timeout_cmd="gtimeout"
-    fi
-
-    if [ -n "$timeout_cmd" ]; then
-        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" codex exec -m "$CODEX_MODEL" "$prompt" \
-            < "$DIFF_FILE" > "$output" 2>&1
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" codex exec -m "$CODEX_MODEL" "$prompt" \
+            < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
         codex exec -m "$CODEX_MODEL" "$prompt" \
-            < "$DIFF_FILE" > "$output" 2>&1
+            < "$DIFF_FILE" > "$output"
     fi
 }
 

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -7,7 +7,8 @@
 #
 # Env:
 #   SKIP_CODEX_REVIEW=1              Skip review
-#   CODEX_MODEL=gpt-5.4        Override model (default: gpt-5.4)
+#   REQUIRE_CODEX_REVIEW=1           Hard fail if codex CLI not found (default: soft skip)
+#   CODEX_MODEL=gpt-5.4              Override model (default: gpt-5.4)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
 
@@ -23,6 +24,11 @@ done
 source "$SCRIPT_DIR/review-prompts.sh"
 source "$SCRIPT_DIR/review-common.sh"
 
+if [ "$SKIP_CODEX_REVIEW" = "1" ] && [ "${REQUIRE_CODEX_REVIEW:-0}" = "1" ]; then
+    echo -e "${RED}ERROR: SKIP_CODEX_REVIEW and REQUIRE_CODEX_REVIEW cannot both be set${NC}" >&2
+    exit 2
+fi
+
 if [ "$SKIP_CODEX_REVIEW" = "1" ]; then
     echo -e "${YELLOW}Skipping Codex review (SKIP_CODEX_REVIEW=1)${NC}"
     exit 0
@@ -31,8 +37,13 @@ fi
 if ! command -v codex &> /dev/null; then
     echo -e "${YELLOW}Warning: codex CLI not found, skipping review${NC}"
     echo -e "${YELLOW}Install: https://developers.openai.com/codex/cli/${NC}"
+    if [ "${REQUIRE_CODEX_REVIEW:-0}" = "1" ]; then
+        echo -e "${RED}ERROR: REQUIRE_CODEX_REVIEW=1 but codex not found${NC}" >&2
+        exit 2
+    fi
     exit 0
 fi
+
 
 # Configuration
 CODEX_MODEL="${CODEX_MODEL:-gpt-5.4}"
@@ -43,8 +54,16 @@ invoke_cli() {
     local prompt=$1
     local output=$2
 
+    # Resolve timeout command (GNU timeout or macOS gtimeout)
+    local timeout_cmd=""
     if command -v timeout &>/dev/null; then
-        timeout "$REVIEW_TIMEOUT_SEC" codex exec -m "$CODEX_MODEL" "$prompt" \
+        timeout_cmd="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+    fi
+
+    if [ -n "$timeout_cmd" ]; then
+        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" codex exec -m "$CODEX_MODEL" "$prompt" \
             < "$DIFF_FILE" > "$output" 2>&1
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
@@ -54,8 +73,8 @@ invoke_cli() {
 }
 
 # Prepare diff (pass through any mode argument: --staged, --branch)
-prepare_diff "$@"
-rc=$?
+rc=0
+prepare_diff "$@" || rc=$?
 if [ "$rc" -eq 1 ]; then
     exit 0  # Nothing to review
 elif [ "$rc" -ne 0 ]; then

--- a/scripts/copilot-review.sh
+++ b/scripts/copilot-review.sh
@@ -4,6 +4,7 @@
 #
 # Env:
 #   SKIP_COPILOT_REVIEW=1            Skip review
+#   REQUIRE_COPILOT_REVIEW=1         Hard fail if copilot CLI not found (default: soft skip)
 #   COPILOT_MODEL=claude-sonnet-4.5  Override model (default: claude-sonnet-4.5)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
@@ -20,6 +21,11 @@ done
 source "$SCRIPT_DIR/review-prompts.sh"
 source "$SCRIPT_DIR/review-common.sh"
 
+if [ "$SKIP_COPILOT_REVIEW" = "1" ] && [ "${REQUIRE_COPILOT_REVIEW:-0}" = "1" ]; then
+    echo -e "${RED}ERROR: SKIP_COPILOT_REVIEW and REQUIRE_COPILOT_REVIEW cannot both be set${NC}" >&2
+    exit 2
+fi
+
 if [ "$SKIP_COPILOT_REVIEW" = "1" ]; then
     echo -e "${YELLOW}Skipping Copilot review (SKIP_COPILOT_REVIEW=1)${NC}"
     exit 0
@@ -28,8 +34,13 @@ fi
 if ! command -v copilot &> /dev/null; then
     echo -e "${YELLOW}Warning: copilot CLI not found, skipping review${NC}"
     echo -e "${YELLOW}Install: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli${NC}"
+    if [ "${REQUIRE_COPILOT_REVIEW:-0}" = "1" ]; then
+        echo -e "${RED}ERROR: REQUIRE_COPILOT_REVIEW=1 but copilot not found${NC}" >&2
+        exit 2
+    fi
     exit 0
 fi
+
 
 # Configuration
 COPILOT_MODEL="${COPILOT_MODEL:-claude-sonnet-4.5}"
@@ -40,8 +51,16 @@ invoke_cli() {
     local prompt=$1
     local output=$2
 
+    # Resolve timeout command (GNU timeout or macOS gtimeout)
+    local timeout_cmd=""
     if command -v timeout &>/dev/null; then
-        timeout "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" --model "$COPILOT_MODEL" \
+        timeout_cmd="timeout"
+    elif command -v gtimeout &>/dev/null; then
+        timeout_cmd="gtimeout"
+    fi
+
+    if [ -n "$timeout_cmd" ]; then
+        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" --model "$COPILOT_MODEL" \
             < "$DIFF_FILE" > "$output" 2>&1
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
@@ -51,8 +70,8 @@ invoke_cli() {
 }
 
 # Prepare diff (pass through any mode argument: --staged, --branch)
-prepare_diff "$@"
-rc=$?
+rc=0
+prepare_diff "$@" || rc=$?
 if [ "$rc" -eq 1 ]; then
     exit 0  # Nothing to review
 elif [ "$rc" -ne 0 ]; then

--- a/scripts/copilot-review.sh
+++ b/scripts/copilot-review.sh
@@ -32,12 +32,12 @@ if [ "$SKIP_COPILOT_REVIEW" = "1" ]; then
 fi
 
 if ! command -v copilot &> /dev/null; then
-    echo -e "${YELLOW}Warning: copilot CLI not found, skipping review${NC}"
-    echo -e "${YELLOW}Install: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli${NC}"
     if [ "${REQUIRE_COPILOT_REVIEW:-0}" = "1" ]; then
         echo -e "${RED}ERROR: REQUIRE_COPILOT_REVIEW=1 but copilot not found${NC}" >&2
         exit 2
     fi
+    echo -e "${YELLOW}Warning: copilot CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli${NC}"
     exit 0
 fi
 
@@ -46,26 +46,26 @@ fi
 COPILOT_MODEL="${COPILOT_MODEL:-claude-sonnet-4.5}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
 
+# Resolve timeout command (GNU timeout or macOS gtimeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+fi
+
 # Define CLI invocation (called by run_all_reviewers)
 invoke_cli() {
     local prompt=$1
     local output=$2
 
-    # Resolve timeout command (GNU timeout or macOS gtimeout)
-    local timeout_cmd=""
-    if command -v timeout &>/dev/null; then
-        timeout_cmd="timeout"
-    elif command -v gtimeout &>/dev/null; then
-        timeout_cmd="gtimeout"
-    fi
-
-    if [ -n "$timeout_cmd" ]; then
-        "$timeout_cmd" "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" --model "$COPILOT_MODEL" \
-            < "$DIFF_FILE" > "$output" 2>&1
+    if [ -n "$TIMEOUT_CMD" ]; then
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" --model "$COPILOT_MODEL" \
+            < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
         copilot -p "$prompt" --model "$COPILOT_MODEL" \
-            < "$DIFF_FILE" > "$output" 2>&1
+            < "$DIFF_FILE" > "$output"
     fi
 }
 

--- a/scripts/cursor-review.sh
+++ b/scripts/cursor-review.sh
@@ -37,12 +37,12 @@ if [ "$SKIP_CURSOR_REVIEW" = "1" ]; then
 fi
 
 if ! command -v cursor-agent &> /dev/null; then
-    echo -e "${YELLOW}Warning: cursor-agent CLI not found, skipping review${NC}"
-    echo -e "${YELLOW}Install: Install Cursor IDE and enable CLI access${NC}"
     if [ "${REQUIRE_CURSOR_REVIEW:-0}" = "1" ]; then
         echo -e "${RED}ERROR: REQUIRE_CURSOR_REVIEW=1 but cursor-agent not found${NC}" >&2
         exit 2
     fi
+    echo -e "${YELLOW}Warning: cursor-agent CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: Install Cursor IDE and enable CLI access${NC}"
     exit 0
 fi
 
@@ -67,7 +67,7 @@ invoke_cli() {
 
     if [ -n "$TIMEOUT_CMD" ]; then
         "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" cursor-agent --print --model "$CURSOR_MODEL" "$prompt" \
-            < "$DIFF_FILE" > "$output" 2>&1
+            < "$DIFF_FILE" > "$output"
     else
         echo -e "${RED}ERROR: 'timeout' command not found. cursor-agent requires timeout protection due to known hanging issue.${NC}" >&2
         echo -e "${YELLOW}Install coreutils: brew install coreutils${NC}" >&2

--- a/scripts/cursor-review.sh
+++ b/scripts/cursor-review.sh
@@ -4,6 +4,7 @@
 #
 # Env:
 #   SKIP_CURSOR_REVIEW=1             Skip review
+#   REQUIRE_CURSOR_REVIEW=1          Hard fail if cursor-agent CLI not found (default: soft skip)
 #   CURSOR_MODEL=auto                Override model (default: auto)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
@@ -25,6 +26,11 @@ done
 source "$SCRIPT_DIR/review-prompts.sh"
 source "$SCRIPT_DIR/review-common.sh"
 
+if [ "$SKIP_CURSOR_REVIEW" = "1" ] && [ "${REQUIRE_CURSOR_REVIEW:-0}" = "1" ]; then
+    echo -e "${RED}ERROR: SKIP_CURSOR_REVIEW and REQUIRE_CURSOR_REVIEW cannot both be set${NC}" >&2
+    exit 2
+fi
+
 if [ "$SKIP_CURSOR_REVIEW" = "1" ]; then
     echo -e "${YELLOW}Skipping Cursor review (SKIP_CURSOR_REVIEW=1)${NC}"
     exit 0
@@ -33,8 +39,13 @@ fi
 if ! command -v cursor-agent &> /dev/null; then
     echo -e "${YELLOW}Warning: cursor-agent CLI not found, skipping review${NC}"
     echo -e "${YELLOW}Install: Install Cursor IDE and enable CLI access${NC}"
+    if [ "${REQUIRE_CURSOR_REVIEW:-0}" = "1" ]; then
+        echo -e "${RED}ERROR: REQUIRE_CURSOR_REVIEW=1 but cursor-agent not found${NC}" >&2
+        exit 2
+    fi
     exit 0
 fi
+
 
 # Configuration
 CURSOR_MODEL="${CURSOR_MODEL:-auto}"
@@ -65,8 +76,8 @@ invoke_cli() {
 }
 
 # Prepare diff (pass through any mode argument: --staged, --branch)
-prepare_diff "$@"
-rc=$?
+rc=0
+prepare_diff "$@" || rc=$?
 if [ "$rc" -eq 1 ]; then
     exit 0  # Nothing to review
 elif [ "$rc" -ne 0 ]; then

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -34,12 +34,12 @@ if [ "$SKIP_GEMINI_REVIEW" = "1" ]; then
 fi
 
 if ! command -v gemini &> /dev/null; then
-    echo -e "${YELLOW}Warning: gemini CLI not found, skipping review${NC}"
-    echo -e "${YELLOW}Install: npm install -g @google/gemini-cli${NC}"
     if [ "${REQUIRE_GEMINI_REVIEW:-0}" = "1" ]; then
         echo -e "${RED}ERROR: REQUIRE_GEMINI_REVIEW=1 but gemini not found${NC}" >&2
         exit 2
     fi
+    echo -e "${YELLOW}Warning: gemini CLI not found, skipping review${NC}"
+    echo -e "${YELLOW}Install: npm install -g @google/gemini-cli${NC}"
     exit 0
 fi
 
@@ -70,12 +70,12 @@ invoke_cli() {
     if [ -n "$TIMEOUT_CMD" ]; then
         "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" gemini -p "$prompt" \
             --sandbox --output-format text "${GEMINI_MODEL_ARGS[@]}" \
-            < "$DIFF_FILE" > "$output" 2>&1
+            < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
         gemini -p "$prompt" \
             --sandbox --output-format text "${GEMINI_MODEL_ARGS[@]}" \
-            < "$DIFF_FILE" > "$output" 2>&1
+            < "$DIFF_FILE" > "$output"
     fi
 }
 

--- a/scripts/gemini-review.sh
+++ b/scripts/gemini-review.sh
@@ -4,6 +4,7 @@
 #
 # Env:
 #   SKIP_GEMINI_REVIEW=1             Skip review
+#   REQUIRE_GEMINI_REVIEW=1          Hard fail if gemini CLI not found (default: soft skip)
 #   GEMINI_MODEL                     Override model (default: Gemini CLI default)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
@@ -22,6 +23,11 @@ done
 source "$SCRIPT_DIR/review-prompts.sh"
 source "$SCRIPT_DIR/review-common.sh"
 
+if [ "$SKIP_GEMINI_REVIEW" = "1" ] && [ "${REQUIRE_GEMINI_REVIEW:-0}" = "1" ]; then
+    echo -e "${RED}ERROR: SKIP_GEMINI_REVIEW and REQUIRE_GEMINI_REVIEW cannot both be set${NC}" >&2
+    exit 2
+fi
+
 if [ "$SKIP_GEMINI_REVIEW" = "1" ]; then
     echo -e "${YELLOW}Skipping Gemini review (SKIP_GEMINI_REVIEW=1)${NC}"
     exit 0
@@ -30,8 +36,13 @@ fi
 if ! command -v gemini &> /dev/null; then
     echo -e "${YELLOW}Warning: gemini CLI not found, skipping review${NC}"
     echo -e "${YELLOW}Install: npm install -g @google/gemini-cli${NC}"
+    if [ "${REQUIRE_GEMINI_REVIEW:-0}" = "1" ]; then
+        echo -e "${RED}ERROR: REQUIRE_GEMINI_REVIEW=1 but gemini not found${NC}" >&2
+        exit 2
+    fi
     exit 0
 fi
+
 
 # Configuration
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
@@ -49,6 +60,7 @@ if command -v timeout &>/dev/null; then
 elif command -v gtimeout &>/dev/null; then
     TIMEOUT_CMD="gtimeout"
 fi
+
 
 # Define CLI invocation (called by run_all_reviewers)
 invoke_cli() {
@@ -68,8 +80,8 @@ invoke_cli() {
 }
 
 # Prepare diff (pass through any mode argument: --staged, --branch)
-prepare_diff "$@"
-rc=$?
+rc=0
+prepare_diff "$@" || rc=$?
 if [ "$rc" -eq 1 ]; then
     exit 0  # Nothing to review
 elif [ "$rc" -ne 0 ]; then

--- a/scripts/review-common.sh
+++ b/scripts/review-common.sh
@@ -143,7 +143,15 @@ _check_diff_size() {
     diff_lines=$(wc -l < "$DIFF_FILE")
 
     if [ "$diff_lines" -gt "$MAX_DIFF_LINES" ]; then
-        echo -e "${YELLOW}Warning: Large diff ($diff_lines lines). Consider breaking into smaller commits.${NC}"
+        echo ""
+        echo -e "${RED}╔══════════════════════════════════════════════════════════╗${NC}"
+        echo -e "${RED}║  ⚠  LARGE DIFF WARNING: ${diff_lines} lines (max: ${MAX_DIFF_LINES})${NC}"
+        echo -e "${RED}║  Diff truncated to ${MAX_DIFF_LINES} lines for review.${NC}"
+        echo -e "${RED}║  Consider breaking into smaller commits for full coverage.${NC}"
+        echo -e "${RED}╚══════════════════════════════════════════════════════════╝${NC}"
+        echo ""
+        # Truncate diff to MAX_DIFF_LINES (use tmp file to avoid $() stripping trailing newlines)
+        head -n "$MAX_DIFF_LINES" "$DIFF_FILE" > "${DIFF_FILE}.tmp" && mv "${DIFF_FILE}.tmp" "$DIFF_FILE"
     fi
 }
 
@@ -189,21 +197,41 @@ run_all_reviewers() {
 }
 
 _run_single_reviewer() {
-    set -e
     local name=$1
     local output="$TEMP_DIR/${name}.md"
+    local stderr_file="$TEMP_DIR/${name}.stderr"
+    local verdict_file="$TEMP_DIR/${name}.verdict"
     local prompt
 
     if ! prompt=$(get_prompt "$name"); then
-        echo "ERROR" > "$TEMP_DIR/${name}.verdict"
+        echo "ERROR" > "$verdict_file"
         echo "Unknown reviewer: $name" > "$output"
         return
     fi
 
     local exit_status=0
-    invoke_cli "$prompt" "$output" || exit_status=$?
+    invoke_cli "$prompt" "$output" 2>"$stderr_file" || exit_status=$?
 
-    parse_verdict "$exit_status" "$output" "$TEMP_DIR/${name}.verdict"
+    # Detect timeout (exit code 124 from `timeout` command)
+    if [ "$exit_status" -eq 124 ]; then
+        echo "TIMEOUT" > "$verdict_file"
+        echo "Reviewer timed out after ${REVIEW_TIMEOUT_SEC:-600}s. Consider increasing REVIEW_TIMEOUT_SEC or reducing the diff." > "$output"
+        if [ -s "$stderr_file" ]; then
+            echo "" >> "$output"
+            echo "--- stderr ---" >> "$output"
+            cat "$stderr_file" >> "$output"
+        fi
+        return
+    fi
+
+    # Append stderr to output on failure for debugging
+    if [ "$exit_status" -ne 0 ] && [ -s "$stderr_file" ]; then
+        echo "" >> "$output"
+        echo "--- stderr ---" >> "$output"
+        cat "$stderr_file" >> "$output"
+    fi
+
+    parse_verdict "$exit_status" "$output" "$verdict_file" || true
 }
 
 # Display results table and return overall verdict
@@ -235,6 +263,8 @@ display_results() {
             verdict_text="✓ PASS"; verdict_color="$GREEN"
         elif [ "$verdict" = "FAIL" ]; then
             verdict_text="✗ FAIL"; verdict_color="$RED"; overall_pass=false
+        elif [ "$verdict" = "TIMEOUT" ]; then
+            verdict_text="⏱ TIMEOUT"; verdict_color="$YELLOW"; overall_pass=false
         else
             verdict_text="? ERROR"; verdict_color="$YELLOW"; overall_pass=false
         fi
@@ -265,7 +295,7 @@ display_results() {
 
         if [ -f "$verdict_file" ]; then
             local v=$(<"$verdict_file")
-            if [ "$v" = "FAIL" ] || [ "$v" = "ERROR" ]; then
+            if [ "$v" = "FAIL" ] || [ "$v" = "ERROR" ] || [ "$v" = "TIMEOUT" ]; then
                 echo -e "${RED}━━━ ${reviewer} Details ━━━${NC}"
                 if [ -f "$output_file" ]; then
                     cat "$output_file"


### PR DESCRIPTION
Closes #336

## Summary

レビュースクリプト群（review-common.sh + 5つの *-review.sh）のエラーハンドリングを包括的に改善。

### review-common.sh
- timeout exit code 124 → `TIMEOUT` verdict に区別（`⏱ TIMEOUT` 表示追加）
- `_run_single_reviewer`: stderr を別ファイルにキャプチャ（invoke_cli 内部の warning 用）
- `_check_diff_size`: large diff を `head > tmp && mv` で安全に truncate + 赤い警告ボックス
- `_run_single_reviewer`: `set -e` 除去 + `parse_verdict || true` で silent exit 防止

### 全5 *-review.sh
- `REQUIRE_*_REVIEW=1` 環境変数で CLI 未検出時の hard fail 対応 (exit 2)
- `SKIP_*` と `REQUIRE_*` の矛盾検出（同時設定でエラー）
- claude/codex/copilot に `gtimeout` フォールバック追加（macOS対応）
- `prepare_diff` の `set -e` 問題 → `cmd || rc=$?` パターンに統一

## セルフレビュー対応
- **silent-failure-hunter**: diff truncation の echo/$() → `head > tmp && mv` に修正、`if/else $?` → `cmd || rc=$?` に修正、SKIP+REQUIRE 矛盾検出追加
- **Codex CLI**: syntax error 検出 → sed 副作用の fi 消失を手動修正済み

## Test Plan
- [x] `bash -n` syntax check 全6ファイルパス
- [x] SKIP + REQUIRE 矛盾検出ロジック追加
- [ ] 各CLI環境での実行テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レビュー必須を切り替える環境変数（REQUIRE_*）を追加。
  * タイムアウト検出と外部タイムアウトコマンドの利用を導入。
  * モデル指定引数の伝播（Gemini向け）とタイムアウト判定をUIに反映。

* **バグ修正**
  * レビュー欠如時の挙動を厳格化（必須設定時はエラー）。
  * 「レビュー対象なし」とその他エラーを正しく区別して終了コードを調整。
  * 標準エラー出力の収集とタイムアウト情報を出力に含める改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->