### PR TITLE
fix: #353 PATTERNS.md の any 型使用・logger署名不整合を修正

### DIFF
--- a/docs-template/03-implementation/PATTERNS.md
+++ b/docs-template/03-implementation/PATTERNS.md
@@ -181,7 +181,7 @@ async function processUser(userId: string): Promise<Result<User>> {
     logger.error('Failed to process user', normalizedError, { userId });
 
     if (normalizedError instanceof ValidationError) {
-      return Result.fail(error);
+      return Result.fail(normalizedError);
     }
     
     return Result.fail(new InternalError('Processing failed'));

--- a/docs-template/03-implementation/PATTERNS.md
+++ b/docs-template/03-implementation/PATTERNS.md
@@ -129,9 +129,16 @@ abstract class AppError extends Error {
   }
 }
 
+// バリデーション詳細の型定義
+interface ValidationDetail {
+  field: string;
+  message: string;
+  constraint?: string;
+}
+
 // 具体的なエラークラス
 class ValidationError extends AppError {
-  constructor(message: string, public details: any[]) {
+  constructor(message: string, public details: ValidationDetail[]) {
     super(message, 'VALIDATION_ERROR', 400);
   }
 }
@@ -170,9 +177,10 @@ async function processUser(userId: string): Promise<Result<User>> {
     return Result.ok(processed);
     
   } catch (error) {
-    logger.error('Failed to process user', { userId, error });
-    
-    if (error instanceof ValidationError) {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    logger.error('Failed to process user', normalizedError, { userId });
+
+    if (normalizedError instanceof ValidationError) {
       return Result.fail(error);
     }
     
@@ -523,10 +531,10 @@ function authMiddleware(req: Request, res: Response, next: NextFunction) {
 
 // 認可デコレーター
 function RequireRole(role: Role) {
-  return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-    const originalMethod = descriptor.value;
-    
-    descriptor.value = async function(...args: any[]) {
+  return function(_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
+
+    descriptor.value = async function(...args: unknown[]) {
       const user = getCurrentUser();
       if (!user.hasRole(role)) {
         throw new ForbiddenError('Insufficient permissions');
@@ -544,11 +552,11 @@ function RequireRole(role: Role) {
 ```typescript
 // キャッシングデコレーター
 function Cacheable(ttl: number = 3600) {
-  return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-    const originalMethod = descriptor.value;
-    const cache = new Map();
-    
-    descriptor.value = async function(...args: any[]) {
+  return function(_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value as (...args: unknown[]) => Promise<unknown>;
+    const cache = new Map<string, { value: unknown; timestamp: number }>();
+
+    descriptor.value = async function(...args: unknown[]) {
       const key = JSON.stringify(args);
       
       if (cache.has(key)) {
@@ -611,13 +619,13 @@ class BatchProcessor<T> {
 ```typescript
 // 構造化ログパターン
 class Logger {
-  private context: Record<string, any> = {};
-  
-  setContext(context: Record<string, any>): void {
+  private context: Record<string, unknown> = {};
+
+  setContext(context: Record<string, unknown>): void {
     this.context = { ...this.context, ...context };
   }
-  
-  info(message: string, meta?: Record<string, any>): void {
+
+  info(message: string, meta?: Record<string, unknown>): void {
     console.log(JSON.stringify({
       level: 'info',
       message,
@@ -626,8 +634,8 @@ class Logger {
       ...meta
     }));
   }
-  
-  error(message: string, error: Error, meta?: Record<string, any>): void {
+
+  error(message: string, error: Error, meta?: Record<string, unknown>): void {
     console.error(JSON.stringify({
       level: 'error',
       message,

--- a/docs-template/03-implementation/PATTERNS.md
+++ b/docs-template/03-implementation/PATTERNS.md
@@ -129,7 +129,7 @@ abstract class AppError extends Error {
   }
 }
 
-// バリデーション詳細の型定義
+// バリデーション詳細の型定義（any[] の代わりに明示的な型を使用し型安全性を確保）
 interface ValidationDetail {
   field: string;
   message: string;
@@ -323,8 +323,9 @@ function fetchUserWithPosts(userId: string): Promise<UserWithPosts> {
     .then(user => fetchPosts(user.id)
       .then(posts => ({ ...user, posts }))
     )
-    .catch(error => {
-      logger.error('Failed to fetch user with posts', error);
+    .catch((error: unknown) => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      logger.error('Failed to fetch user with posts', normalizedError);
       throw new DataFetchError('Could not load user data');
     });
 }
@@ -340,7 +341,8 @@ async function fetchUserWithPosts(userId: string): Promise<UserWithPosts> {
     const posts = await fetchPosts(user.id);
     return { ...user, posts };
   } catch (error) {
-    logger.error('Failed to fetch user with posts', error);
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    logger.error('Failed to fetch user with posts', normalizedError);
     throw new DataFetchError('Could not load user data');
   }
 }


### PR DESCRIPTION
Closes #353

## 概要

PATTERNS.md 内のコード例で `any` 型が使用されていた箇所と、`logger.error` の署名が不整合だった箇所を修正。

## 変更内容

### 1. `any` 型の排除
- `ValidationError` の `details: any[]` → `ValidationDetail[]`（型定義を新規追加）
- デコレーター（`RequireRole`, `Cacheable`）の `target: any`, `...args: any[]` → `unknown` に変更
- `Map` のジェネリクスを明示的に型指定

### 2. Logger 署名の統一
- `Logger` クラスの `Record<string, any>` → `Record<string, unknown>` に統一
- Section 3 の `logger.error('...', { userId, error })` → `logger.error('...', normalizedError, { userId })` に修正（Section 9 定義と一致）
- Section 4 の Promise Chain / Async/Await パターンにも error normalization を追加

### 3. セルフレビューで発見した追加修正
- `Result.fail(error)` → `Result.fail(normalizedError)` に修正（unknown 型のまま渡していたバグ）
- `ValidationDetail` のコメントに `any[]` 禁止の意図を明記

## セルフレビュー結果

### PR Review Toolkit（Claude系 3エージェント並列）
- **code-reviewer**: Critical 1件（Result.fail バグ）→ 修正済み
- **comment-analyzer**: Important 1件（Section 4 logger署名）→ 修正済み
- **silent-failure-hunter**: Critical 1件（同上）→ 修正済み

### Codex CLI（GPT 5.4 クロスモデルレビュー）
- Medium 1件（error normalization で非Error オブジェクトが潰される）→ テンプレートのシンプルさ優先で留保
- `any` 残存なし、logger 署名整合を確認

## テストプラン

- [ ] `docs-template/03-implementation/PATTERNS.md` の変更内容を目視確認
- [ ] コード例が TypeScript strict mode で矛盾なく動作する記述であることを確認
- [ ] MCP build check は既存の `js-yaml` 型定義エラーで失敗（本PR起因ではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * エラーハンドリング、ロギング、キャッシング、認可のパターンドキュメントを更新し、型安全性を強化しました。
  * 新しいValidationDetailパターンと、より厳密な型定義がドキュメント例に反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->