### PR TITLE
docs: #361 削除事故防止ハーネス設計と安全なスキル作成ガードを追加

### DIFF
--- a/docs-template/.github/skills/skill-authoring-safety/SKILL.md
+++ b/docs-template/.github/skills/skill-authoring-safety/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: skill-authoring-safety
+description: >-
+  Creates and reviews agent skills safely by enforcing deletion-prevention
+  harness rules: no fixed absolute temp paths, no cwd-dependent cleanup, no
+  wildcard deletes, no workspace-external file operations, no silent cleanup
+  failures, and mandatory temp-root validation before any destructive command.
+  Use when creating a new skill, updating an existing SKILL.md, or reviewing
+  prompts/runbooks that include temp files, extraction, cleanup, PowerShell,
+  bash, rm, del, Remove-Item, or archive expansion.
+metadata:
+  version: "1.0.0"
+  author: feel-flow
+  tags: "skill-authoring, safety, deletion-prevention, hooks, powershell, temp-files"
+  references: "docs-template/05-operations/deployment/agent-deletion-prevention-harness.md, docs-template/MASTER.md"
+---
+
+# スキル作成安全ガード
+
+SKILL.md や関連 runbook を作成・更新するときに、削除事故や workspace 外操作を招く危険な記述を防ぐためのスキル。
+
+このスキルの目的は、「スキルを作るスキル」を安全側に倒し、テンポラリ作成・展開・cleanup を含む記述でも削除防止ハーネスを最初から組み込むことです。
+
+## 1. 基本原則
+
+1. 固定絶対パスを temp として決め打ちしない
+2. `Get-Location` を workspace root の代わりに使わない
+3. cleanup は相対パス、ワイルドカード、ドライブ直下を禁止する
+4. 削除対象は workspace 配下の専用 temp root に限定する
+5. cleanup 失敗を `SilentlyContinue` で握りつぶさない
+6. 削除前に temp root 配下かどうかを必ず検証する
+
+## 2. 生成時の必須チェックリスト
+
+新しいスキルや runbook を作るときは、以下を満たしているか確認する。
+
+- [ ] temp パスが対象ファイルまたは workspace 配下から導出されている
+- [ ] 固定ドライブ名、固定プロジェクト名、ユーザー固有パスが入っていない
+- [ ] cleanup が実行ごとの一意な temp ディレクトリ単位になっている
+- [ ] `rm`, `del`, `Remove-Item`, `find -delete` に wildcard が含まれていない
+- [ ] cleanup 前のパス検証関数がある
+- [ ] 削除対象が temp root 自体ではなく、その配下の subdirectory になっている
+- [ ] Windows を主対象にする場合、sandbox 前提の説明になっていない
+
+## 3. 禁止パターン
+
+以下のパターンを含むスキル文面は生成しない。
+
+```powershell
+# ❌ 固定絶対パス
+$tempDir = "d:\Git\project\_temp_extract"
+
+# ❌ cwd 依存
+$workspaceRoot = (Get-Location).Path
+
+# ❌ wildcard cleanup
+Remove-Item -Force "d:\Git\project\_temp_*_output.md"
+
+# ❌ temp root 丸ごと削除
+Remove-Item -Recurse -Force $tempRoot
+
+# ❌ cleanup 失敗の握りつぶし
+Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+```
+
+```bash
+# ❌ 相対削除
+rm -rf ./*
+
+# ❌ workspace 外の固定パス
+rm -rf /tmp/project-extract
+
+# ❌ find -delete
+find . -name '*temp*' -delete
+```
+
+## 4. 推奨パターン
+
+### PowerShell
+
+```powershell
+function New-ScopedTempDirectory($sourceFilePath, $toolName) {
+    $resolvedSourcePath = [System.IO.Path]::GetFullPath($sourceFilePath)
+    $sourceDirectory = Split-Path -Parent $resolvedSourcePath
+    $tempRoot = Join-Path $sourceDirectory (".tmp_" + $toolName)
+    $runId = [guid]::NewGuid().ToString("N")
+    $tempDir = Join-Path $tempRoot $runId
+
+    if (-not (Test-Path -LiteralPath $tempRoot)) {
+        New-Item -ItemType Directory -Path $tempRoot | Out-Null
+    }
+
+    New-Item -ItemType Directory -Path $tempDir | Out-Null
+
+    return @{ TempRoot = $tempRoot; TempDir = $tempDir }
+}
+
+function Remove-TempPathSafely($path, $tempRoot) {
+    $resolvedPath = [System.IO.Path]::GetFullPath($path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($tempRoot)
+    $pathRoot = [System.IO.Path]::GetPathRoot($resolvedPath)
+
+    if ($resolvedPath -eq $pathRoot) {
+        throw "Refusing to delete a drive root: $resolvedPath"
+    }
+
+    if (-not $resolvedPath.StartsWith($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to delete a path outside temp root: $resolvedPath"
+    }
+
+    if (Test-Path -LiteralPath $resolvedPath) {
+        Remove-Item -LiteralPath $resolvedPath -Recurse -Force
+    }
+}
+```
+
+### bash / zsh
+
+```bash
+source_file="<target-file>"
+source_dir="$(cd "$(dirname "$source_file")" && pwd)"
+temp_root="$source_dir/.tmp_toolname"
+run_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+temp_dir="$temp_root/$run_id"
+
+mkdir -p "$temp_dir"
+
+case "$temp_dir" in
+  "$temp_root"/*) rm -rf -- "$temp_dir" ;;
+  *) echo "Refusing to delete outside temp root: $temp_dir" >&2; exit 1 ;;
+esac
+```
+
+## 5. Windows 主体の注意事項
+
+- Windows では terminal sandbox を前提にしない
+- 削除防止は approval、deny ルール、hook を主手段とする
+- PowerShell 記述では `Remove-Item -LiteralPath` を優先する
+- ドライブレター付きの固定パス例をテンプレートに入れない
+
+## 6. スキル生成時の出力方針
+
+スキルを生成するときは、以下の順序で書く。
+
+1. 目的
+2. 適用対象
+3. 安全上の必須ルール
+4. 危険パターンを避けた実行例
+5. cleanup の安全条件
+6. 既知の制限事項
+
+temp や cleanup を扱うスキルでは、必ず「安全上の必須ルール」を本文前半に置くこと。
+
+## 7. レビュー観点
+
+既存スキルをレビューするときは、以下を重点的に確認する。
+
+- temp path が他プロジェクトへ持ち越せない固定値になっていないか
+- cleanup が一意な temp subdirectory ではなく root 全体を消していないか
+- wildcard cleanup がないか
+- `ErrorAction SilentlyContinue` や `2>/dev/null` で事故兆候を隠していないか
+- instructions と cleanup サンプルが矛盾していないか
+
+## 8. 関連ドキュメント
+
+- [../../../05-operations/deployment/agent-deletion-prevention-harness.md](../../../05-operations/deployment/agent-deletion-prevention-harness.md)
+- [../../../MASTER.md](../../../MASTER.md)

--- a/docs-template/.github/skills/skill-authoring-safety/SKILL.md
+++ b/docs-template/.github/skills/skill-authoring-safety/SKILL.md
@@ -99,12 +99,18 @@ function Remove-TempPathSafely($path, $tempRoot) {
     $resolvedPath = [System.IO.Path]::GetFullPath($path)
     $resolvedRoot = [System.IO.Path]::GetFullPath($tempRoot)
     $pathRoot = [System.IO.Path]::GetPathRoot($resolvedPath)
+  $normalizedRoot = $resolvedRoot.TrimEnd('\\', '/')
+  $rootWithSeparator = $normalizedRoot + [System.IO.Path]::DirectorySeparatorChar
 
     if ($resolvedPath -eq $pathRoot) {
         throw "Refusing to delete a drive root: $resolvedPath"
     }
 
-    if (-not $resolvedPath.StartsWith($resolvedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    if ($resolvedPath -eq $normalizedRoot) {
+        throw "Refusing to delete the temp root itself: $resolvedPath"
+    }
+
+    if (-not $resolvedPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
         throw "Refusing to delete a path outside temp root: $resolvedPath"
     }
 

--- a/docs-template/05-operations/DEPLOYMENT.md
+++ b/docs-template/05-operations/DEPLOYMENT.md
@@ -14,12 +14,13 @@ updated: "YYYY-MM-DD"
 ## 📖 構成
 
 | ドキュメント | 内容 | 推奨読み順 |
-|------------|------|----------|
+| ------------ | ---- | ---------- |
 | [github-setup.md](./deployment/github-setup.md) | GitHub初期設定（ラベル・Release Drafter） | ⭐⭐⭐⭐⭐ 0th |
 | [git-workflow.md](./deployment/git-workflow.md) | AI駆動Git Workflow全体 | ⭐⭐⭐⭐⭐ 1st |
 | [self-review.md](./deployment/self-review.md) | セルフレビュー詳細（PR作成前） | ⭐⭐⭐⭐ 2nd |
 | [devin-pre-pr-review.md](./deployment/devin-pre-pr-review.md) | Devin Pre-PRレビューシステム（5エージェント並列） | ⭐⭐⭐⭐ 2.5th |
 | [automated-code-review.md](./deployment/automated-code-review.md) | 自動コードレビュー（Claude Code + Husky） | ⭐⭐⭐⭐ - |
+| [agent-deletion-prevention-harness.md](./deployment/agent-deletion-prevention-harness.md) | 削除事故防止ハーネス設計 | ⭐⭐⭐⭐ - |
 | [knowledge-management.md](./deployment/knowledge-management.md) | ナレッジ体系化（マージ前） | ⭐⭐⭐⭐ 3rd |
 | [ace-cycle.md](./deployment/ace-cycle.md) | ACEサイクル（Playbook増分更新） | ⭐⭐⭐⭐ 3.5th |
 | [ai-tools-integration.md](./deployment/ai-tools-integration.md) | AIツール統合設定 | ⭐⭐⭐ - |
@@ -80,6 +81,7 @@ Git Flowベースで、**テスト・セルフレビュー（PR前）** と **AC
 - **セルフレビュー**: [deployment/self-review.md](./deployment/self-review.md)
 - **ナレッジ管理**: [deployment/knowledge-management.md](./deployment/knowledge-management.md)
 - **AIツール統合**: [deployment/ai-tools-integration.md](./deployment/ai-tools-integration.md)
+- **削除事故防止**: [deployment/agent-deletion-prevention-harness.md](./deployment/agent-deletion-prevention-harness.md)
 
 ### ブランチ戦略（Git Flow準拠）
 
@@ -117,7 +119,7 @@ GitHub Actions/GitLab CI/Jenkinsによる自動化パイプライン。
 ### 環境構成
 
 | 環境 | 用途 | URL例 | インフラ |
-|------|------|-------|---------|
+| ---- | ---- | ----- | -------- |
 | Development | 開発環境 | dev.example.com | 軽量構成 |
 | Staging | ステージング | staging.example.com | 本番同等 |
 | Production | 本番環境 | app.example.com | 高可用性 |
@@ -184,7 +186,7 @@ GitHub Actions/GitLab CI/Jenkinsによる自動化パイプライン。
 ### 定期メンテナンス
 
 | タスク | 頻度 | 手順 | 担当 |
-|-------|------|------|------|
+| ----- | ---- | ---- | ---- |
 | セキュリティパッチ | 月次 | patch-update.sh | DevOps |
 | 証明書更新 | 3ヶ月 | cert-renewal.sh | DevOps |
 | ログローテーション | 週次 | 自動 | - |
@@ -212,7 +214,7 @@ PRマージ後のブランチ切り替え忘れを防ぐため、セッション
 ### 検索クエリマッピング
 
 | 知りたいこと | 参照ドキュメント | セクション |
-|------------|----------------|----------|
+| ------------ | ---------------- | ---------- |
 | Gitワークフロー全体 | [git-workflow.md](./deployment/git-workflow.md) | 全体 |
 | セルフレビュー方法 | [self-review.md](./deployment/self-review.md) | 全体 |
 | ナレッジ記録方法 | [knowledge-management.md](./deployment/knowledge-management.md) | 全体 |
@@ -220,6 +222,7 @@ PRマージ後のブランチ切り替え忘れを防ぐため、セッション
 | PRレビュー対応 | [git-workflow.md](./deployment/git-workflow.md) | ステップ7 |
 | レビュー結果の対応ルール | [review-response-policy.md](./deployment/review-response-policy.md) | 全体 |
 | ワークフロー運用原則 | [workflow-principles.md](./deployment/workflow-principles.md) | 全体 |
+| 削除事故防止ハーネス | [agent-deletion-prevention-harness.md](./deployment/agent-deletion-prevention-harness.md) | 全体 |
 | クロスモデルレビュー | [multi-cli-review-orchestration.md](./deployment/multi-cli-review-orchestration.md) | クロスモデルレビュー |
 | CI/CD設定 | [ci-cd.md](./deployment/ci-cd.md) | GitHub Actions |
 | インフラ構成 | [infrastructure.md](./deployment/infrastructure.md) | Terraform |

--- a/docs-template/05-operations/deployment/agent-deletion-prevention-harness.md
+++ b/docs-template/05-operations/deployment/agent-deletion-prevention-harness.md
@@ -1,0 +1,309 @@
+# 削除防止ハーネス設計
+
+> **Parent**: [DEPLOYMENT.md](../DEPLOYMENT.md) | **Related**: [ai-tools-integration.md](./ai-tools-integration.md) | [workflow-principles.md](./workflow-principles.md)
+
+## 概要
+
+AIエージェントによる削除事故を防ぐための多層防御ハーネスを定義します。
+
+この文書の主対象は **Windows 環境** です。macOS は terminal sandbox による補強が可能ですが、sandbox は削除禁止ではなく境界制御であるため、本書では補足扱いに留めます。
+
+本ハーネスは、テンポラリファイルの作成位置を直接指定できない場合でも、cleanup を含む破壊的操作を安全側に倒すことを目的とします。
+
+---
+
+## 問題設定
+
+削除事故は、以下のような経路で発生します。
+
+1. エージェントが terminal 経由で一時ファイルまたは一時ディレクトリを作成する
+2. cleanup のために削除コマンドを組み立てる
+3. 削除対象が相対パス、ワイルドカード、または cwd 依存で評価される
+4. 想定と異なるディレクトリでコマンドが実行される
+5. 自動承認により確認なしで実行される
+
+**重要な前提**:
+- built-in file tools は workspace 境界を持つ
+- terminal commands は shell の cwd と構文解釈の影響を受ける
+- したがって、削除事故の主要リスクは file tool よりも terminal cleanup 側にある
+
+### 典型的な危険パターン
+
+以下のような skill / prompt / runbook は危険である。
+
+```powershell
+$tempDir = "d:\Git\cogniphotobase\_temp_pptx_extract"
+if (Test-Path $tempDir) { Remove-Item -Recurse -Force $tempDir }
+Expand-Archive -Path "<対象pptxファイルパス>" -DestinationPath $tempDir -Force
+
+Remove-Item -Recurse -Force "d:\Git\cogniphotobase\_temp_pptx_extract" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "d:\Git\cogniphotobase\_temp_xlsx_extract" -ErrorAction SilentlyContinue
+Remove-Item -Force "d:\Git\cogniphotobase\_temp_*_output.md" -ErrorAction SilentlyContinue
+```
+
+**危険な理由**:
+- 固定ドライブ、固定絶対パスを前提にしている
+- 実行対象プロジェクトと無関係なディレクトリを削除対象にしている
+- 実行前 cleanup を無条件に行っている
+- ワイルドカード cleanup を含んでいる
+- cleanup 対象が workspace 内の専用ディレクトリに限定されていない
+
+この種の記述は、別プロジェクトにスキルを持ち込んだときに誤削除へ直結する。
+
+---
+
+## 設計原則
+
+### 原則1: temp 配置先指定より cleanup 制御を優先する
+
+テンポラリファイルの作成位置を常に制御できるとは限らない。
+そのため、防御の主眼は「どこに作るか」ではなく「どこを削除できるか」に置く。
+
+### 原則2: 相対削除を禁止する
+
+以下は原則禁止:
+- `rm -rf .`
+- `rm -rf ./*`
+- `del /s *`
+- `Remove-Item -Recurse .`
+- `find ... -delete`
+- ワイルドカードを含む一括削除
+
+削除対象は、検証済みの絶対パスまたは workspace 内の専用 cleanup ディレクトリ配下に限定する。
+
+### 原則3: 破壊的操作は terminal auto-approve の allowlist に入れない
+
+破壊的コマンドは「便利だから許可する」対象ではない。
+削除系コマンドは deny または ask を基本とする。
+
+### 原則4: Bypass Approvals / Autopilot を最終防衛線にしない
+
+自動承認モードは確認を飛ばすため、削除防止は hooks などの強制ガードで実装する。
+
+### 原則5: cleanup 専用領域を分離する
+
+一時ファイルの cleanup が必要な場合は、workspace 配下の専用ディレクトリを使用する。
+
+例:
+- `.tmp/agent/`
+- `.artifacts/agent/`
+- `tmp/agent-sandbox/`
+
+cleanup 対象を専用領域に閉じ込めることで、削除対象の検証を単純化する。
+
+### 原則6: OS のテンポラリをそのまま信用しない
+
+Windows の `$env:TEMP` や macOS の一時領域そのものを自由削除領域とみなしてはならない。
+AI エージェントが削除できるのは、workspace 内で明示的に許可した専用ディレクトリ配下に限定する。
+
+---
+
+## 安全な PowerShell パターン
+
+PowerShell を使う skill では、以下のように workspace 内の専用ディレクトリを作成し、その配下だけを cleanup 対象にする。
+
+```powershell
+function New-ScopedTempDirectory($sourceFilePath, $toolName) {
+    $resolvedSourcePath = [System.IO.Path]::GetFullPath($sourceFilePath)
+    $sourceDirectory = Split-Path -Parent $resolvedSourcePath
+    $sandboxRoot = Join-Path $sourceDirectory (".tmp_" + $toolName)
+    $runId = [guid]::NewGuid().ToString("N")
+    $extractRoot = Join-Path $sandboxRoot $runId
+
+    if (-not (Test-Path -LiteralPath $sandboxRoot)) {
+        New-Item -ItemType Directory -Path $sandboxRoot | Out-Null
+    }
+
+    New-Item -ItemType Directory -Path $extractRoot | Out-Null
+
+    return @{
+        SandboxRoot = $sandboxRoot
+        ExtractRoot = $extractRoot
+    }
+}
+
+$tempContext = New-ScopedTempDirectory "<対象ファイルパス>" "openxml-reader"
+$sandboxRoot = $tempContext.SandboxRoot
+$extractRoot = $tempContext.ExtractRoot
+Expand-Archive -Path "<対象ファイルパス>" -DestinationPath $extractRoot -Force
+
+# 作業完了後は sandboxRoot 配下のみ cleanup する
+if ($extractRoot.StartsWith($sandboxRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    Remove-Item -LiteralPath $extractRoot -Recurse -Force
+}
+```
+
+**このパターンの要点**:
+- `Get-Location` ではなく対象ファイル基準で temp を作る
+- 対象ファイルの近傍に専用 sandbox を閉じ込める
+- 削除対象を 1 つの検証済みディレクトリに限定する
+- ワイルドカード削除を使わない
+- プロジェクト外の絶対パスを使わない
+- cleanup 前に許可済みルート配下か検証する
+
+---
+
+## OS 差分
+
+| 項目 | Windows | macOS |
+| ---- | ------- | ----- |
+| terminal sandbox | 基本的に利用不可 | 利用可能 |
+| 削除防止の主手段 | approval + hook + deny ルール | approval + hook + deny ルール + sandbox |
+| 推奨方針 | terminal cleanup を強く制限 | sandbox で境界制御しつつ削除自体は hook で制限 |
+
+### Windows
+
+Windows では sandbox を前提にできないため、削除防止は以下の多層防御で成立させる。
+
+### macOS
+
+macOS では sandbox で許可範囲外へのアクセスを抑制できる。
+ただし、sandbox 内では削除も可能であるため、sandbox は削除禁止機能ではない。
+
+---
+
+## ハーネス構成
+
+| レイヤー | 役割 | 防げること | 防げないこと |
+| -------- | ---- | ---------- | ------------ |
+| Instructions / Skills | AIへの行動規範を与える | 誤った cleanup 方針の提案 | 悪いコマンドの実行そのもの |
+| Custom Agent の tool 制限 | 不要な tools を外す | terminal 利用の頻度低減 | 許可済み terminal 内の誤削除 |
+| `chat.tools.terminal.autoApprove` | 危険コマンドを deny/ask | 削除系自動承認 | シェル構文の回避技法 |
+| `chat.tools.terminal.blockDetectedFileWrites` | workspace 外書き込みの検知 | 外側への明白な write | 検知漏れする複雑構文 |
+| `PreToolUse` hook | 実行前に強制ブロック | 危険コマンド、危険パス、相対削除 | hook 自体の不備 |
+| Agent Debug Logs / Chat Debug View | 監査と原因分析 | 事故原因の特定 | 実行済みの削除 |
+
+**結論**: hook が最終防衛線であり、instructions だけでは不十分。
+
+---
+
+## Windows 向け最小構成
+
+### 1. terminal auto-approve で削除系を deny
+
+最低限、以下を deny する:
+- `rm`
+- `rmdir`
+- `del`
+- `erase`
+- `Remove-Item`
+- `find`（削除用途を含む場合）
+- `powershell` / `pwsh` のうち削除系サブコマンドを含むもの
+
+### 2. workspace 外 write の検知を有効化
+
+`chat.tools.terminal.blockDetectedFileWrites` は `outsideWorkspace` を維持する。
+
+### 3. `PreToolUse` hook で削除コマンドを強制審査
+
+以下の条件では `deny` または `ask` を返す:
+- 相対パス削除
+- ワイルドカード削除
+- ドライブ直下の削除
+- ルート相当の削除
+- cleanup 専用ディレクトリ外の削除
+- `Bypass Approvals` 中の削除系 terminal 実行
+
+### 4. cleanup 対象を専用ディレクトリ配下に固定
+
+削除可能なのは次に限定する:
+- `<workspace>/.tmp/agent/**`
+- `<workspace>/.artifacts/agent/**`
+
+PowerShell 系 skill では、用途別にさらに細分化してよい。
+
+例:
+- `<workspace>/.tmp/agent/openxml-reader/extract/**`
+- `<workspace>/.tmp/agent/openxml-reader/output/**`
+
+### 5. 絶対パス検証を必須化
+
+cleanup 前に以下を満たすこと:
+- 絶対パスである
+- workspace 配下である
+- 許可済み cleanup ルート配下である
+- ルートディレクトリ自身ではなく、その配下のみを対象にしている
+
+### 6. skill 内の記述で禁止すべき例
+
+以下は skill 文面として禁止:
+- 特定ドライブ直下を temp として決め打ちする
+- project 名を含む固定絶対パスを削除対象にする
+- `_temp_*` のようなワイルドカード cleanup を推奨する
+- `ErrorAction SilentlyContinue` で cleanup 失敗を握りつぶす
+
+---
+
+## macOS 向け補強構成
+
+macOS では、Windows 向け最小構成に加えて terminal sandbox を有効化する。
+
+### sandbox の使い方
+
+- `allowWrite` は workspace 内の cleanup 専用ディレクトリを中心に絞る
+- `denyWrite` で `.git/`, `.vscode/`, `secrets/`, `docs-template/` など重要領域を保護する
+- `denyRead` で機密ファイルを遮断する
+
+### 注意
+
+sandbox は「その中なら自由に削除してよい」という意味ではない。
+許可範囲内でも削除自体は可能なので、削除防止は引き続き hook と approval で担保する。
+
+---
+
+## 禁止ルール
+
+以下は OS を問わず禁止:
+
+1. cwd 前提の cleanup
+2. ワイルドカードによる一括削除
+3. terminal でのドライブ直下またはルート直下操作
+4. ユーザー確認なしの cleanup 例外化
+5. hook 無効化を前提とした運用
+6. `--no-verify`, `SKIP_*=1` 相当の未承認バイパス
+
+---
+
+## 承認ルール
+
+| 操作 | 既定動作 | 条件 |
+| ---- | -------- | ---- |
+| file tool による workspace 内編集 | 通常運用 | review 前提 |
+| terminal での非破壊コマンド | allow または ask | 明示的な安全コマンドのみ |
+| cleanup 専用ディレクトリ内の削除 | ask | 絶対パスかつ許可済みルート配下 |
+| cleanup 専用ディレクトリ外の削除 | deny | 例外なし |
+| workspace 外の write / delete | deny | 例外なし |
+
+---
+
+## 監査と事故解析
+
+事故またはヒヤリハット発生時は、以下を確認する。
+
+1. Agent Debug Logs で `execute/runInTerminal` の呼び出し有無を確認する
+2. 実行されたコマンド全文を確認する
+3. 削除対象が相対パスか絶対パスかを確認する
+4. 直前に作成された temp ディレクトリや移動処理を確認する
+5. approval モードが `Default Approvals`, `Bypass Approvals`, `Autopilot` のどれだったかを確認する
+6. hook が loaded されていたか、deny/ask が発火したかを確認する
+
+---
+
+## 導入チェックリスト
+
+- [ ] Windows を主対象とした deny ルールを設定した
+- [ ] 削除系コマンドを terminal auto-approve から除外した
+- [ ] `blockDetectedFileWrites` の設定を確認した
+- [ ] `PreToolUse` hook で相対削除と workspace 外削除をブロックした
+- [ ] cleanup 専用ディレクトリを workspace 内に定義した
+- [ ] Bypass Approvals / Autopilot の利用条件を定義した
+- [ ] Agent Debug Logs で事故解析できる体制を用意した
+
+---
+
+## 関連ドキュメント
+
+- [ai-tools-integration.md](./ai-tools-integration.md) -- AIツール別の安全性制御
+- [workflow-principles.md](./workflow-principles.md) -- 運用原則
+- [../../.github/skills/skill-authoring-safety/SKILL.md](../../.github/skills/skill-authoring-safety/SKILL.md) -- スキル作成時の安全ガード
+- [../DEPLOYMENT.md](../DEPLOYMENT.md) -- 運用ハブ

--- a/docs-template/05-operations/deployment/agent-deletion-prevention-harness.md
+++ b/docs-template/05-operations/deployment/agent-deletion-prevention-harness.md
@@ -122,21 +122,45 @@ function New-ScopedTempDirectory($sourceFilePath, $toolName) {
     }
 }
 
+function Remove-TempPathSafely($path, $sandboxRoot) {
+    $resolvedPath = [System.IO.Path]::GetFullPath($path)
+    $resolvedRoot = [System.IO.Path]::GetFullPath($sandboxRoot)
+    $pathRoot = [System.IO.Path]::GetPathRoot($resolvedPath)
+    $normalizedRoot = $resolvedRoot.TrimEnd('\\', '/')
+    $rootWithSeparator = $normalizedRoot + [System.IO.Path]::DirectorySeparatorChar
+
+    if ($resolvedPath -eq $pathRoot) {
+        throw "Refusing to delete a drive root: $resolvedPath"
+    }
+
+    if ($resolvedPath -eq $normalizedRoot) {
+        throw "Refusing to delete the sandbox root itself: $resolvedPath"
+    }
+
+    if (-not $resolvedPath.StartsWith($rootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to delete a path outside sandbox root: $resolvedPath"
+    }
+
+    if (Test-Path -LiteralPath $resolvedPath) {
+        Remove-Item -LiteralPath $resolvedPath -Recurse -Force
+    }
+}
+
 $tempContext = New-ScopedTempDirectory "<対象ファイルパス>" "openxml-reader"
 $sandboxRoot = $tempContext.SandboxRoot
 $extractRoot = $tempContext.ExtractRoot
 Expand-Archive -Path "<対象ファイルパス>" -DestinationPath $extractRoot -Force
 
 # 作業完了後は sandboxRoot 配下のみ cleanup する
-if ($extractRoot.StartsWith($sandboxRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-    Remove-Item -LiteralPath $extractRoot -Recurse -Force
-}
+Remove-TempPathSafely $extractRoot $sandboxRoot
 ```
 
 **このパターンの要点**:
 - `Get-Location` ではなく対象ファイル基準で temp を作る
 - 対象ファイルの近傍に専用 sandbox を閉じ込める
 - 削除対象を 1 つの検証済みディレクトリに限定する
+- sandbox root 自体の削除を禁止する
+- 文字列 prefix ではなくディレクトリ境界つきで配下判定する
 - ワイルドカード削除を使わない
 - プロジェクト外の絶対パスを使わない
 - cleanup 前に許可済みルート配下か検証する

--- a/docs/AI_CONFIG_BEST_PRACTICES.md
+++ b/docs/AI_CONFIG_BEST_PRACTICES.md
@@ -330,6 +330,24 @@ AIがGit hookの存在を知らないと、hook失敗時に混乱したり、`--
 **AI向けルール**: hookは絶対にユーザーの許可なくスキップしないこと（`--no-verify`, `SKIP_*=1`）
 ```
 
+### 削除防止ハーネスの追加
+
+hooks を導入する場合、lint や format だけではなく **削除事故防止** を最優先で含めることを推奨します。
+
+特に GitHub Copilot Agent のように terminal を使うAIでは、workspace 内編集と terminal cleanup を分けて扱う必要があります。file edit は workspace 境界の中で扱えても、terminal cleanup は cwd やシェル構文の影響を受けるためです。
+
+最低限、設定ファイルまたは hook で以下を明文化してください。
+
+- 削除系コマンドは auto-approve に入れない
+- 相対パス削除を禁止する
+- ワイルドカード削除を禁止する
+- cleanup 対象は workspace 配下の専用ディレクトリに限定する
+- `Bypass Approvals` や `Autopilot` を使う場合も `PreToolUse` hook を最終防衛線にする
+
+Windows を主対象とする場合は、sandbox を前提にせず approval と hook で防御する設計が必要です。macOS では sandbox による補強が可能ですが、sandbox は削除禁止ではなく境界制御です。
+
+詳細な設計標準は [agent-deletion-prevention-harness.md](../docs-template/05-operations/deployment/agent-deletion-prevention-harness.md) を参照してください。
+
 ---
 
 ## 8. Common Issuesテーブル
@@ -373,6 +391,7 @@ CLAUDE.mdはClaude Codeが自動的に読み込む設定ファイルです。マ
 - [x] **スコープ外問題の取り扱い**
 - [x] **Review Feedback Responseパターン**
 - [x] **Automated Hooks 情報**
+- [x] **削除防止ハーネス情報**
 - [x] **Common Issues テーブル**
 - [x] 参照ドキュメント一覧
 


### PR DESCRIPTION
Closes #361

## Summary
- docs-template に削除事故防止ハーネス設計を追加
- DEPLOYMENT と AI_CONFIG_BEST_PRACTICES から辿れるように導線を追加
- skill authoring 時に危険な temp / cleanup 記述を避ける safety skill を追加

## Test Plan
- `git diff --check`
- changed markdown files: diagnostics clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメンテーション**
  * 削除事故防止ハーネスの新規ドキュメントを追加（設計原則、OS別対策、監査・実装チェックリスト含む）
  * スキル作成時の安全ガイドラインを新設（危険な削除パターンの禁止、スコープ限定の一時領域運用、レビュー項目）
  * 展開ドキュメントの索引と参照を更新
  * AI 設定ベストプラクティスに削除防止要件を追記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->