### PR TITLE
feat: #367 ACE autonomous テンプレとドキュメント

### DIFF
--- a/.claude/commands/init-docs.md
+++ b/.claude/commands/init-docs.md
@@ -73,6 +73,14 @@ MASTER.md は特に重要です。以下を必ず反映してください:
 
 作成したファイル一覧を表示し、次のステップとして `/validate-docs` の実行を推奨してください。
 
+### 6. （任意）ACE autonomous テンプレートの案内
+
+ユーザーが **マージ後の ACE を subagent + worktree で自動化**したい場合のみ、AskUserQuestion で希望を確認する。
+
+- **オプション例**: 「はい（テンプレートの場所を案内）」/「いいえ（スキップ）」
+- **はい**の場合: `docs-template/05-operations/deployment/ace-autonomous.md` と `docs-template/scripts/ace/` をコピー先の目安とともに説明する。feature flag（`ACE_SUBAGENT_ENABLED` 等）は **デフォルト無効** で開始することを必ず伝える。
+- **いいえ**の場合: 既存の手動 `/ace-curate` 運用で問題ない旨を一言添える。
+
 ## 重要ルール
 
 - テンプレートの構造と必須セクションは変更しないこと

--- a/.claude/commands/setup-ai-config.md
+++ b/.claude/commands/setup-ai-config.md
@@ -140,6 +140,13 @@ bash scripts/setup-multi-review.sh
 生成したファイルの一覧と、各ファイルの要約を表示してください。
 Multi-CLI Review Agent のセットアップ結果も含めて報告してください。
 
+### 8. （任意）ACE autonomous テンプレートの案内
+
+ユーザーが **ACE ナレッジキャプチャの autonomous 化**（post-merge → subagent → worktree）に関心を示した場合、または Multi-CLI / Git 運用の文脈で自動化を聞かれた場合のみ、AskUserQuestion で希望を確認する。
+
+- **オプション例**: 「案内する」/「スキップ」
+- **案内する**を選んだ場合: `docs-template/05-operations/deployment/ace-autonomous.md`、`docs-template/scripts/ace/`、`.claude/agents/ace-capture.md` テンプレのコピー先、環境変数（`ACE_SUBAGENT_ENABLED` / `ACE_SUBAGENT_AUTO_MERGE` / `ACE_GARDEN_WALL_PATHS`）の **明示 opt-in** を説明する。
+
 ## 重要ルール
 
 - 既存ファイルがある場合は上書き前に必ず確認すること

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -63,3 +63,7 @@ Claude Codeセッション開始時に自動的に実行され、以下のよう
 3. スクリプトに実行権限を付与: `chmod +x .claude/hooks/your-script.sh`
 
 詳細は [docs/05-operations/DEPLOYMENT.md](../../docs/05-operations/DEPLOYMENT.md) の「開発環境の最適化」セクションを参照してください。
+
+### post-merge.ace.sample.sh（参考）
+
+ACE autonomous 化のテンプレートとして、`docs-template/.claude/hooks/post-merge.ace.sample.sh` を用意しています（Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)）。`ACE_SUBAGENT_ENABLED=1` のときだけ `scripts/ace/run-subagent.sh` をバックグラウンド起動する例です。詳細は [ace-autonomous.md](../../docs-template/05-operations/deployment/ace-autonomous.md) を参照してください。

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -66,4 +66,4 @@ Claude Codeセッション開始時に自動的に実行され、以下のよう
 
 ### post-merge.ace.sample.sh（参考）
 
-ACE autonomous 化のテンプレートとして、`docs-template/.claude/hooks/post-merge.ace.sample.sh` を用意しています（Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)）。`ACE_SUBAGENT_ENABLED=1` のときだけ `scripts/ace/run-subagent.sh` をバックグラウンド起動する例です。詳細は [ace-autonomous.md](../../docs-template/05-operations/deployment/ace-autonomous.md) を参照してください。
+ACE autonomous 化のテンプレートとして、`docs-template/.claude/hooks/post-merge.ace.sample.sh` を用意しています（Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)）。`ACE_SUBAGENT_ENABLED=1` のときだけ `scripts/ace/run-subagent.sh` をバックグラウンド起動する例です。サンプルは存在すれば **`.ace-capture/hook-env.sh`** を `source` し、`ACE_GARDEN_WALL_PATHS` 等を hook に渡します。詳細は [ace-autonomous.md](../../docs-template/05-operations/deployment/ace-autonomous.md) を参照してください。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run MCP server tests
         run: npm --prefix mcp test
 
+      - name: Run ACE script unit tests
+        run: npm run test:ace-scripts
+
       - name: Validate docs structure
         run: npm run validate -- docs-template
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ npm install && npm run setup
 
 大規模な `node_modules` や `git worktree` を併用する開発環境では、macOS のファイルディスクリプタ上限設定も推奨です。詳細は [docs/MAXFILES_SETUP_GUIDE.md](./docs/MAXFILES_SETUP_GUIDE.md) を参照してください。
 
+### ACE ナレッジキャプチャの autonomous 化（任意）
+
+PR マージ後の `/ace-curate` 手動実行を、**別プロセスの subagent + git worktree** に任せる推奨パターンがあります（feature flag でデフォルト無効）。テンプレートと運用手順は次を参照してください。
+
+- [ace-autonomous.md](./docs-template/05-operations/deployment/ace-autonomous.md)（概要・4 ガード・shadow 運用）
+- [docs-template/scripts/ace/README.md](./docs-template/scripts/ace/README.md)（配置ファイル一覧）
+
 ### 利用可能なコマンド
 
 | コマンド | 説明 |

--- a/docs-template/.claude/agents/ace-capture.md
+++ b/docs-template/.claude/agents/ace-capture.md
@@ -1,0 +1,42 @@
+---
+name: ace-capture
+description: >
+  PR マージ後に専用 worktree 上で ACE Playbook の Generate→Reflect→Curate を実行する。
+  garden wall 内のファイルのみ編集し、検証通過後に draft PR を作成する。
+model: inherit
+---
+
+# ACE Capture（autonomous）
+
+あなたは **ACE ナレッジキャプチャ専用の subagent** です。親セッションとは独立した worktree で動作し、以下を厳守します。
+
+## Garden wall（必須）
+
+- **許可されたパスのみ**を読み書きする。許可リストは環境変数 `ACE_GARDEN_WALL_PATHS`（カンマ区切り）で与えられる。
+- 例: `docs/playbooks/,docs/08-knowledge/` — いずれのプレフィックスにも一致しないパスへの作成・編集・削除は **禁止**。
+- 設定が空の場合は **一切のファイル変更を行わない**（ログに理由を出して終了）。
+
+## 作業内容
+
+1. **Generate**: マージ済み PR / Issue の一次情報（`gh pr view` / `gh issue view` 等）から知見候補を抽出する。
+2. **Reflect**: 既存 Playbook エントリとの重複・矛盾を確認する。
+3. **Curate**: プロジェクトの ACE サイクル手順（例: `docs/05-operations/deployment/ace-cycle.md`）に従い、末尾追記のみ行う（既存エントリ本文の書き換え禁止）。
+
+## 自動マージ（オプション）
+
+環境変数 `ACE_SUBAGENT_AUTO_MERGE=1` のときのみ、プロジェクトが定義した **4 ガード**（path whitelist / 検証コマンド / タイトル・ブランチ規約 / 削除比チェック）を **すべて**満たした場合に限り、`gh pr merge --squash` を実行してよい。
+
+それ以外は **draft PR まで**とし、人間の確認を待つ。
+
+## 禁止事項
+
+- garden wall 外への変更、シークレットの出力、force push、履歴の書き換え。
+- Playbook の **物理削除** や既存エントリの Insight/Context/Action の **黙示的な全文置換**。
+- カテゴリ肥大化の分割作業をこの subagent 内で完結させること（閾値超過時は `check-category-size.ts` の指針に従い、別 Issue 起票用のメモのみ残す）。
+
+## 参照ドキュメント（テンプレート内パス）
+
+プロジェクトにコピー後は、実際の `docs/` 配下のパスに読み替えること。
+
+- ACE サイクル手順: `docs-template/05-operations/deployment/ace-cycle.md` をプロジェクトの `docs/05-operations/deployment/ace-cycle.md` 等へ合わせる。
+- autonomous 運用の全体像: `docs-template/05-operations/deployment/ace-autonomous.md`。

--- a/docs-template/.claude/hooks/post-merge.ace.sample.sh
+++ b/docs-template/.claude/hooks/post-merge.ace.sample.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# post-merge から ACE subagent を起動するサンプル（Issue #367）
+# 実運用では既存の post-merge フローへ追記するか、git hook の post-merge に配置する。
+
+set -euo pipefail
+
+readonly ENABLED_VALUE='1'
+
+if [[ "${ACE_SUBAGENT_ENABLED:-0}" != "$ENABLED_VALUE" ]]; then
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+readonly REPO_ROOT=$(git rev-parse --show-toplevel)
+readonly RUNNER="${REPO_ROOT}/scripts/ace/run-subagent.sh"
+
+if [[ ! -x "$RUNNER" ]]; then
+  echo "post-merge ace: 実行ファイルが見つかりません: $RUNNER" >&2
+  exit 0
+fi
+
+mkdir -p "${REPO_ROOT}/.ace-capture"
+# 実運用ではログローテーションや ACE_GARDEN_WALL_PATHS の継承を確認すること。
+nohup "$RUNNER" >>"${REPO_ROOT}/.ace-capture/post-merge.log" 2>&1 &

--- a/docs-template/.claude/hooks/post-merge.ace.sample.sh
+++ b/docs-template/.claude/hooks/post-merge.ace.sample.sh
@@ -15,6 +15,15 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 readonly REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Git GUI や CI の merge では環境変数が空のことがある。リポジトリ内の
+# .ace-capture/hook-env.sh に export ACE_GARDEN_WALL_PATHS=... 等を書き、ここで source する。
+readonly HOOK_ENV_FILE="${REPO_ROOT}/.ace-capture/hook-env.sh"
+if [[ -f "$HOOK_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$HOOK_ENV_FILE"
+fi
+
 readonly RUNNER="${REPO_ROOT}/scripts/ace/run-subagent.sh"
 
 if [[ ! -x "$RUNNER" ]]; then

--- a/docs-template/05-operations/DEPLOYMENT.md
+++ b/docs-template/05-operations/DEPLOYMENT.md
@@ -23,6 +23,7 @@ updated: "YYYY-MM-DD"
 | [agent-deletion-prevention-harness.md](./deployment/agent-deletion-prevention-harness.md) | 削除事故防止ハーネス設計 | ⭐⭐⭐⭐ - |
 | [knowledge-management.md](./deployment/knowledge-management.md) | ナレッジ体系化（マージ前） | ⭐⭐⭐⭐ 3rd |
 | [ace-cycle.md](./deployment/ace-cycle.md) | ACEサイクル（Playbook増分更新） | ⭐⭐⭐⭐ 3.5th |
+| [ace-autonomous.md](./deployment/ace-autonomous.md) | ACE autonomous（subagent + worktree、任意） | ⭐⭐⭐ 3.6th |
 | [ai-tools-integration.md](./deployment/ai-tools-integration.md) | AIツール統合設定 | ⭐⭐⭐ - |
 | [ci-cd.md](./deployment/ci-cd.md) | CI/CDパイプライン | ⭐⭐⭐ 4th |
 | [infrastructure.md](./deployment/infrastructure.md) | インフラ構成 | ⭐⭐⭐ - |

--- a/docs-template/05-operations/deployment/ace-autonomous.md
+++ b/docs-template/05-operations/deployment/ace-autonomous.md
@@ -1,0 +1,92 @@
+# ACE ナレッジキャプチャの autonomous 化（subagent + worktree）
+
+> **Parent**: [DEPLOYMENT.md](../DEPLOYMENT.md) | **関連**: [ace-cycle.md](./ace-cycle.md) | [knowledge-management.md](./knowledge-management.md) | [ACE フレームワーク概念](../../../docs/ACE_FRAMEWORK.md)
+
+## 概要
+
+従来は PR マージ後に開発者が `/ace-curate` 等を手動実行し、セッション内で LLM が Playbook を直接編集する運用でした。Playbook が肥大化するほど **ユーザー拘束** と **編集 drift リスク** が増えます。
+
+**autonomous パターン**では、マージ完了後に **別プロセス**（例: `claude -p` + `nohup` + `disown`）で **専用 subagent** を起動し、**独立した git worktree** 上で Generate → Reflect → Curate → draft PR までを完結させます。条件を満たす場合のみ **squash マージを自動化** し、親の Claude Code セッションから切り離します。
+
+## 推奨セットアップ（テンプレート）
+
+以下をプロジェクトにコピーし、パス・環境変数を調整してください。
+
+| 種別 | テンプレートパス（本リポジトリ） | 配置先の例 |
+|------|----------------------------------|------------|
+| Subagent 定義 | [`docs-template/.claude/agents/ace-capture.md`](../../.claude/agents/ace-capture.md) | `.claude/agents/ace-capture.md` |
+| 起動オーケストレータ | [`docs-template/scripts/ace/run-subagent.sh`](../../scripts/ace/run-subagent.sh) | `scripts/ace/run-subagent.sh` |
+| カテゴリ肥大化検知 | [`docs-template/scripts/ace/check-category-size.ts`](../../scripts/ace/check-category-size.ts) | `scripts/ace/check-category-size.ts` |
+| post-merge からの呼び出し例 | [`docs-template/.claude/hooks/post-merge.ace.sample.sh`](../../.claude/hooks/post-merge.ace.sample.sh) | 既存の post-merge に追記または参考実装 |
+| 導入手順 | [`docs-template/scripts/ace/README.md`](../../scripts/ace/README.md) | （参照のみ） |
+
+詳細なインストール手順は [scripts/ace/README.md](../../scripts/ace/README.md) を参照してください。
+
+## 実行モデル（全体像）
+
+```text
+post-merge hook（任意）
+  → feature flag ON のときのみ
+  → scripts/ace/run-subagent.sh
+       → 排他ロック（mkdir ベース等）
+       → git worktree add（専用ディレクトリ）
+       → claude -p --agent ace-capture --permission-mode bypassPermissions（例）
+       → draft PR / 条件付き squash merge
+       → worktree 削除・ロック解放
+```
+
+- **親セッションからの分離**: `nohup` / `disown` 等でシェルジョブを切り離し、マージ直後にターミナルを閉じても継続可能にします。
+- **`ACE_CLAUDE_CMD`**: 信頼できる固定コマンドのみを設定し、未検証の外部入力を連結しないこと（シェルインジェクション対策）。
+- **garden wall**: 変更を許可するパスを **環境変数 `ACE_GARDEN_WALL_PATHS`**（カンマ区切り）でホワイトリスト化し、自動マージ時の blast radius を限定します（プロジェクトごとに必ず設定）。
+- **Git の使い分け**: リポジトリルートや ref の解決には `git rev-parse` 等の **スクリプト向けコマンド** を使い、worktree のライフサイクルは `git worktree` に任せます（低レベル API での再実装は非推奨）。
+
+## 4 ガード（自動マージ前の最低限）
+
+1. **Path whitelist**: `ACE_GARDEN_WALL_PATHS` 外への変更がないこと（PR diff で検証）。
+2. **検証コマンド通過**: プロジェクトで定めた `ace:check` / `ace:verify` 等が成功すること。
+3. **ブランチ・PR タイトル規約**: 自動 PR がチームの命名規則に従うこと。
+4. **削除・追加比**: 意図しない大規模削除がないこと（閾値はプロジェクトで定数化）。
+
+## Feature flags（デフォルト無効）
+
+**デフォルトは無効**とし、`.claude/settings.local.json` の env や CI のシークレットで **明示 opt-in** してください。
+
+| 変数 | 意味 | 推奨初期値 |
+|------|------|------------|
+| `ACE_SUBAGENT_ENABLED` | post-merge 等から subagent 起動を行うか | `0`（無効） |
+| `ACE_SUBAGENT_AUTO_MERGE` | ガード通過後に squash マージまで自動で行うか | `0`（無効） |
+| `ACE_GARDEN_WALL_PATHS` | 編集を許可するパス（カンマ区切り） | プロジェクト固有（必須で設定） |
+| `ACE_PLAYBOOK_PATH` | `check-category-size.ts` が読む Playbook ファイル | 例: `docs/08-knowledge/PLAYBOOK.md` |
+
+## Shadow 運用（段階導入）
+
+1. `ACE_SUBAGENT_ENABLED=1` かつ `ACE_SUBAGENT_AUTO_MERGE=0` で **draft PR のみ**自動生成し、人間がレビュー。
+2. 3〜5 PR 程度で成功率・ロールバック有無を記録（[CASE_STUDIES.md](../../../docs/CASE_STUDIES.md) へ追記可能）。
+3. 問題なければ `ACE_SUBAGENT_AUTO_MERGE=1` を限定メンバーまたは特定ブランチのみで有効化。
+
+## Playbook 肥大化と別 Issue 起票
+
+カテゴリあたりのエントリ数が閾値を超えた場合、**subagent 内で分割作業を続けない**方針を推奨します。`check-category-size.ts` が検知し、**別 Issue の起票**（手動または `gh issue create`）に委ねることで責務を分離します。
+
+実行例:
+
+```bash
+npx --yes tsx scripts/ace/check-category-size.ts path/to/PLAYBOOK.md
+```
+
+## レビュー戦略（任意）
+
+docs-only の自動 PR で、構造検証（例: `ace:verify`）が CI で保証できる場合、**Copilot 等の API クォータを人間の PR に温存**する目的で、自動 PR のレビューをスキップする判断をチームで取ることがあります。セキュリティ・コンプライアンス要件に合わせて必ず合意してください。
+
+## 関連 Issue・実装参照
+
+- 本フレームワークへのテンプレ追加: [GitHub #367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)
+- 実装元（別プロダクト）: FeelFlow ID Platform 等での運用検証後、[CASE_STUDIES.md](../../../docs/CASE_STUDIES.md) にメトリクスを追記する（プレースホルダー済み）
+
+## Changelog
+
+### [1.0.0] - 2026-04-27
+
+#### 追加
+
+- autonomous 化パターンの推奨ドキュメントとテンプレート一式（Issue #367）

--- a/docs-template/05-operations/deployment/ace-autonomous.md
+++ b/docs-template/05-operations/deployment/ace-autonomous.md
@@ -40,6 +40,17 @@ post-merge hook（任意）
 - **garden wall**: 変更を許可するパスを **環境変数 `ACE_GARDEN_WALL_PATHS`**（カンマ区切り）でホワイトリスト化し、自動マージ時の blast radius を限定します（プロジェクトごとに必ず設定）。
 - **Git の使い分け**: リポジトリルートや ref の解決には `git rev-parse` 等の **スクリプト向けコマンド** を使い、worktree のライフサイクルは `git worktree` に任せます（低レベル API での再実装は非推奨）。
 
+### Git hook と環境変数
+
+GUI の Git クライアントや一部の CI では、マージ実行時に **`ACE_GARDEN_WALL_PATHS` が空のまま** `post-merge` が動き、`run-subagent.sh` が exit 2 になることがあります。対策として次を推奨します。
+
+1. リポジトリに **`.ace-capture/hook-env.sh`**（git 管理するかしないかはチーム方針で決定）を置き、`export ACE_GARDEN_WALL_PATHS=...` など必要な変数を記述する。
+2. `post-merge.ace.sample.sh` と同様に、hook の先頭で `source "${REPO_ROOT}/.ace-capture/hook-env.sh"` を実行する（サンプルは既にこの source を含む）。
+
+### 排他ロックの腐敗（mkdir ロック）
+
+異常終了で `.ace-capture/instance.lock` が残ると、以降の実行が常にスキップされます。手動で **`rmdir .ace-capture/instance.lock`**（空ディレクトリであることを確認）して解除してください。長期運用では mtime に基づく stale 解除を独自に足す選択肢もあります。
+
 ## 4 ガード（自動マージ前の最低限）
 
 1. **Path whitelist**: `ACE_GARDEN_WALL_PATHS` 外への変更がないこと（PR diff で検証）。
@@ -57,6 +68,7 @@ post-merge hook（任意）
 | `ACE_SUBAGENT_AUTO_MERGE` | ガード通過後に squash マージまで自動で行うか | `0`（無効） |
 | `ACE_GARDEN_WALL_PATHS` | 編集を許可するパス（カンマ区切り） | プロジェクト固有（必須で設定） |
 | `ACE_PLAYBOOK_PATH` | `check-category-size.ts` が読む Playbook ファイル | 例: `docs/08-knowledge/PLAYBOOK.md` |
+| `ACE_MAX_ENTRIES_PER_CATEGORY` | カテゴリあたりの最大エントリ件数 | 省略時は `130`。**非数値や 0 以下は無効**として既定値にフォールバックし、stderr に警告を出す |
 
 ## Shadow 運用（段階導入）
 
@@ -84,6 +96,12 @@ docs-only の自動 PR で、構造検証（例: `ace:verify`）が CI で保証
 - 実装元（別プロダクト）: FeelFlow ID Platform 等での運用検証後、[CASE_STUDIES.md](../../../docs/CASE_STUDIES.md) にメトリクスを追記する（プレースホルダー済み）
 
 ## Changelog
+
+### [1.0.1] - 2026-04-27
+
+#### 変更
+
+- PR レビュー反映: hook 用 `hook-env.sh`、`ACE_MAX_ENTRIES_PER_CATEGORY` 無効時の警告、ロック腐敗の手順、エントリ ID 正規表現を 3 桁以上に拡張
 
 ### [1.0.0] - 2026-04-27
 

--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -17,6 +17,8 @@ ACE (Agentic Context Engineering) サイクルは、レビュー完了後・マ�
 
 **チーム開発（参考）**: PLAYBOOK.mdのコンフリクトリスクがあるため、ACE更新は別ブランチ/別PRで対応することも検討
 
+**autonomous（任意）**: マージ後に subagent と専用 worktree でキャプチャを非同期化するパターン。導入は [ace-autonomous.md](./ace-autonomous.md) と `docs-template/scripts/ace/` のテンプレートを参照（Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)）。
+
 **所要時間**: 5〜15分（AIツール支援あり）
 
 ---
@@ -286,6 +288,7 @@ git commit -m "knowledge: ACE-006,ACE-007 [performance,testing] Prisma N+1防止
 - **概念説明**: [ACE フレームワーク](../../../docs/ACE_FRAMEWORK.md) - ACE の理論的背景
 - **Playbook テンプレート**: [PLAYBOOK.md](../../08-knowledge/PLAYBOOK.md) - エントリの追記先
 - **ナレッジ管理**: [knowledge-management.md](./knowledge-management.md) - GitHub Discussions ベースの管理
+- **autonomous 化**: [ace-autonomous.md](./ace-autonomous.md) - subagent + worktree（任意）
 - **Git ワークフロー**: [git-workflow.md](./git-workflow.md) - ワークフロー全体の中での位置づけ
 - **親ドキュメント**: [DEPLOYMENT.md](../DEPLOYMENT.md) - 運用ガイド索引
 

--- a/docs-template/05-operations/deployment/knowledge-management.md
+++ b/docs-template/05-operations/deployment/knowledge-management.md
@@ -67,6 +67,8 @@ GitHub Discussions は **人間が読むためのナラティブ（物語的記�
 
 詳細: [ace-cycle.md](./ace-cycle.md)
 
+マージ後のキャプチャを **人手から切り離す** 場合は、[ace-autonomous.md](./ace-autonomous.md) の autonomous パターン（feature flag・garden wall・shadow 運用）を参照してください。
+
 ---
 
 ## ナレッジ分類体系

--- a/docs-template/scripts/ace/README.md
+++ b/docs-template/scripts/ace/README.md
@@ -1,0 +1,31 @@
+# scripts/ace — ACE autonomous キャプチャ用テンプレート
+
+Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367) で追加された **推奨パターン** のファイル群です。プロジェクトルートを基準にコピーして利用してください。
+
+## 含まれるファイル
+
+| ファイル | 説明 |
+|----------|------|
+| `run-subagent.sh` | ロック取得、`git worktree` 作成、`claude -p` 起動、後片付けの骨子 |
+| `check-category-size.ts` | Playbook 内の Category ごとの件数を数え、閾値超過で非ゼロ終了 |
+| `docs-template/.claude/agents/ace-capture.md` | Subagent 用プロンプト（コピー先は `.claude/agents/`） |
+
+post-merge からの呼び出し例は `docs-template/.claude/hooks/post-merge.ace.sample.sh` を参照してください。
+
+## インストール手順（概要）
+
+1. `scripts/ace/` をプロジェクトにコピーする。
+2. `.claude/agents/ace-capture.md` をコピーする。
+3. `chmod +x scripts/ace/run-subagent.sh`
+4. `.claude/settings.local.json`（または CI の環境変数）に **デフォルト無効** の feature flag を設定する（`ace-autonomous.md` 参照）。
+5. `ACE_GARDEN_WALL_PATHS` を **必ず** プロジェクト用に設定する（未設定時は `run-subagent.sh` が起動を拒否する）。
+
+## check-category-size.ts の実行
+
+Node 20+ を前提とします。TypeScript をそのまま実行する例:
+
+```bash
+npx --yes tsx scripts/ace/check-category-size.ts docs/08-knowledge/PLAYBOOK.md
+```
+
+環境変数 `ACE_MAX_ENTRIES_PER_CATEGORY`（省略時は `130`）で閾値を変更できます。

--- a/docs-template/scripts/ace/README.md
+++ b/docs-template/scripts/ace/README.md
@@ -28,4 +28,8 @@ Node 20+ を前提とします。TypeScript をそのまま実行する例:
 npx --yes tsx scripts/ace/check-category-size.ts docs/08-knowledge/PLAYBOOK.md
 ```
 
-環境変数 `ACE_MAX_ENTRIES_PER_CATEGORY`（省略時は `130`）で閾値を変更できます。
+環境変数 `ACE_MAX_ENTRIES_PER_CATEGORY`（省略時は `130`）で閾値を変更できます。値が **非数値または 1 未満**のときは既定値 `130` にフォールバックし、標準エラーに警告を出します。
+
+### post-merge 用の環境変数ファイル
+
+Git GUI 等では hook に環境変数が渡らないことがあります。`.ace-capture/hook-env.sh` に `export ACE_GARDEN_WALL_PATHS=...` を書き、`post-merge.ace.sample.sh` が自動で `source` する流れを推奨します（詳細は [ace-autonomous.md](../../05-operations/deployment/ace-autonomous.md)）。

--- a/docs-template/scripts/ace/check-category-size.test.ts
+++ b/docs-template/scripts/ace/check-category-size.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { analyzePlaybookMarkdown } from "./check-category-size";
+
+describe("analyzePlaybookMarkdown", () => {
+  it("HTML コメント内の ACE 見出しは無視し、実エントリのみ数える", () => {
+    const md = `
+<!-- 追記例:
+### ACE-001: コメント内の偽エントリ
+
+| フィールド | 値 |
+| Category | security |
+-->
+
+### ACE-001: 実エントリ
+
+| フィールド | 値 |
+| Category | coding |
+| Origin | PR #1 |
+`;
+
+    const result = analyzePlaybookMarkdown(md);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.totalEntries).toBe(1);
+      expect(result.histogram.coding).toBe(1);
+      expect(result.histogram.security).toBeUndefined();
+    }
+  });
+
+  it("ACE-1000 のように 4 桁以上の ID もエントリとして扱う", () => {
+    const md = `
+### ACE-1000: 将来の連番
+
+| フィールド | 値 |
+| Category | process |
+| Origin | PR #999 |
+`;
+
+    const result = analyzePlaybookMarkdown(md);
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.totalEntries).toBe(1);
+      expect(result.histogram.process).toBe(1);
+    }
+  });
+
+  it("ACE 見出しが無い場合は error を返す", () => {
+    const result = analyzePlaybookMarkdown("# 見出しのみ\n");
+    expect(result.kind).toBe("error");
+  });
+});

--- a/docs-template/scripts/ace/check-category-size.ts
+++ b/docs-template/scripts/ace/check-category-size.ts
@@ -10,7 +10,8 @@ const EXIT_THRESHOLD_EXCEEDED = 1;
 const EXIT_USAGE_ERROR = 2;
 
 const DEFAULT_MAX_ENTRIES_PER_CATEGORY = 130;
-const ACE_ENTRY_HEADER_PATTERN = /^### ACE-\d{3}:/m;
+/** PLAYBOOK の ID 規則（ACE-001 形式）。3 桁以上の連番にも対応する。 */
+const ACE_ENTRY_HEADER_PATTERN = /^### ACE-\d{3,}:/m;
 const CATEGORY_TABLE_LINE_PATTERN = /^\|\s*Category\s*\|\s*([^|]+)\|/im;
 
 export type CategoryHistogram = Readonly<Record<string, number>>;
@@ -54,7 +55,7 @@ export function analyzePlaybookMarkdown(content: string): AnalyzeResult {
   if (segments.length === 0) {
     return {
       kind: "error",
-      message: "ACE エントリ見出し（### ACE-NNN:）が見つかりません。",
+      message: "ACE エントリ見出し（### ACE-数字:）が見つかりません。",
     };
   }
   const histogram: Record<string, number> = {};
@@ -83,8 +84,12 @@ function parseMaxPerCategory(): number {
   if (raw === undefined || raw.trim() === "") {
     return DEFAULT_MAX_ENTRIES_PER_CATEGORY;
   }
-  const parsed = Number.parseInt(raw, 10);
+  const trimmed = raw.trim();
+  const parsed = Number.parseInt(trimmed, 10);
   if (!Number.isFinite(parsed) || parsed < 1) {
+    console.warn(
+      `ace-check: ACE_MAX_ENTRIES_PER_CATEGORY="${trimmed}" は無効のため、既定値 ${String(DEFAULT_MAX_ENTRIES_PER_CATEGORY)} を使います。`,
+    );
     return DEFAULT_MAX_ENTRIES_PER_CATEGORY;
   }
   return parsed;

--- a/docs-template/scripts/ace/check-category-size.ts
+++ b/docs-template/scripts/ace/check-category-size.ts
@@ -1,0 +1,159 @@
+/**
+ * ACE Playbook の Category ごとのエントリ件数を数え、閾値超過で終了コード 1 を返すテンプレート（Issue #367）。
+ * 実行例: npx --yes tsx scripts/ace/check-category-size.ts path/to/PLAYBOOK.md
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const EXIT_OK = 0;
+const EXIT_THRESHOLD_EXCEEDED = 1;
+const EXIT_USAGE_ERROR = 2;
+
+const DEFAULT_MAX_ENTRIES_PER_CATEGORY = 130;
+const ACE_ENTRY_HEADER_PATTERN = /^### ACE-\d{3}:/m;
+const CATEGORY_TABLE_LINE_PATTERN = /^\|\s*Category\s*\|\s*([^|]+)\|/im;
+
+export type CategoryHistogram = Readonly<Record<string, number>>;
+
+export type AnalyzeSuccess = Readonly<{
+  readonly kind: "ok";
+  readonly histogram: CategoryHistogram;
+  readonly totalEntries: number;
+}>;
+
+export type AnalyzeFailure = Readonly<{
+  readonly kind: "error";
+  readonly message: string;
+}>;
+
+export type AnalyzeResult = AnalyzeSuccess | AnalyzeFailure;
+
+function trimCategoryValue(raw: string): string {
+  return raw.replace(/\s+/gu, " ").trim();
+}
+
+function incrementHistogram(
+  histogram: Record<string, number>,
+  categoryKey: string,
+): void {
+  const next = (histogram[categoryKey] ?? 0) + 1;
+  histogram[categoryKey] = next;
+}
+
+function stripHtmlBlockComments(source: string): string {
+  return source.replace(/<!--[\s\S]*?-->/gu, "");
+}
+
+/**
+ * PLAYBOOK.md 本文から ACE エントリブロックを走査し、Category 行を集計する。
+ * HTML コメント内の追記例（### ACE-001 など）を除外するため、先にコメントを除去する。
+ */
+export function analyzePlaybookMarkdown(content: string): AnalyzeResult {
+  const cleaned = stripHtmlBlockComments(content);
+  const segments = cleaned.split(ACE_ENTRY_HEADER_PATTERN).slice(1);
+  if (segments.length === 0) {
+    return {
+      kind: "error",
+      message: "ACE エントリ見出し（### ACE-NNN:）が見つかりません。",
+    };
+  }
+  const histogram: Record<string, number> = {};
+
+  for (const segment of segments) {
+    const match = segment.match(CATEGORY_TABLE_LINE_PATTERN);
+    if (!match?.[1]) {
+      return {
+        kind: "error",
+        message: "Category 行を解析できない ACE ブロックがあります。",
+      };
+    }
+    const categoryKey = trimCategoryValue(match[1]);
+    incrementHistogram(histogram, categoryKey);
+  }
+
+  return {
+    kind: "ok",
+    histogram,
+    totalEntries: segments.length,
+  };
+}
+
+function parseMaxPerCategory(): number {
+  const raw = process.env.ACE_MAX_ENTRIES_PER_CATEGORY;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_MAX_ENTRIES_PER_CATEGORY;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_MAX_ENTRIES_PER_CATEGORY;
+  }
+  return parsed;
+}
+
+function resolvePlaybookPath(argv: readonly string[]): string | undefined {
+  const fromArg = argv[2];
+  if (fromArg && fromArg.trim() !== "") {
+    return path.resolve(fromArg);
+  }
+  const fromEnv = process.env.ACE_PLAYBOOK_PATH;
+  if (fromEnv && fromEnv.trim() !== "") {
+    return path.resolve(fromEnv);
+  }
+  return undefined;
+}
+
+function formatHistogram(histogram: CategoryHistogram): string {
+  return Object.entries(histogram)
+    .map(([key, count]) => `${key}: ${String(count)}`)
+    .join("\n");
+}
+
+function main(): number {
+  const playbookPath = resolvePlaybookPath(process.argv);
+  if (!playbookPath) {
+    console.error(
+      "引数に PLAYBOOK.md のパスを渡すか、ACE_PLAYBOOK_PATH を設定してください。",
+    );
+    return EXIT_USAGE_ERROR;
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(playbookPath, "utf8");
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`読み込み失敗: ${message}`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const analyzed = analyzePlaybookMarkdown(content);
+  if (analyzed.kind === "error") {
+    console.error(analyzed.message);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const maxAllowed = parseMaxPerCategory();
+  const overCategories: string[] = [];
+
+  for (const [categoryKey, count] of Object.entries(analyzed.histogram)) {
+    if (count > maxAllowed) {
+      overCategories.push(`${categoryKey} (${String(count)} > ${String(maxAllowed)})`);
+    }
+  }
+
+  console.log(`Playbook: ${playbookPath}`);
+  console.log(`総エントリ数: ${String(analyzed.totalEntries)}`);
+  console.log("カテゴリ別件数:\n" + formatHistogram(analyzed.histogram));
+
+  if (overCategories.length > 0) {
+    console.error(
+      "閾値超過カテゴリがあります。別 Issue で分割方針を起票してください:\n- " +
+        overCategories.join("\n- "),
+    );
+    return EXIT_THRESHOLD_EXCEEDED;
+  }
+
+  return EXIT_OK;
+}
+
+process.exitCode = main();

--- a/docs-template/scripts/ace/run-subagent.sh
+++ b/docs-template/scripts/ace/run-subagent.sh
@@ -2,6 +2,10 @@
 # ACE autonomous キャプチャ — worktree 上で subagent を起動するテンプレート（Issue #367）
 # 使用法: リポジトリルートから scripts/ace/run-subagent.sh（コピー先に合わせて調整）
 # 前提: ACE_GARDEN_WALL_PATHS が設定されていること（未設定なら即終了）
+#
+# ロックの腐敗: 異常終了で instance.lock が残った場合は手動で
+#   rmdir .ace-capture/instance.lock
+# を実行してから再試行する（中にファイルが無い空ディレクトリであること）。
 
 set -euo pipefail
 

--- a/docs-template/scripts/ace/run-subagent.sh
+++ b/docs-template/scripts/ace/run-subagent.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ACE autonomous キャプチャ — worktree 上で subagent を起動するテンプレート（Issue #367）
+# 使用法: リポジトリルートから scripts/ace/run-subagent.sh（コピー先に合わせて調整）
+# 前提: ACE_GARDEN_WALL_PATHS が設定されていること（未設定なら即終了）
+
+set -euo pipefail
+
+readonly ACE_SUBAGENT_LOCK_DIR_RELATIVE='.ace-capture'
+readonly ACE_LOCK_INSTANCE_DIR_NAME='instance.lock'
+readonly ACE_WORKTREE_PARENT_RELATIVE='.ace-capture/worktrees'
+readonly ACE_WORKTREE_DIR_PREFIX='ace-capture-'
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo 'ace-capture: git リポジトリ内で実行してください。' >&2
+  exit 2
+fi
+
+readonly REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+if [[ -z "${ACE_GARDEN_WALL_PATHS:-}" ]]; then
+  echo 'ace-capture: ACE_GARDEN_WALL_PATHS が未設定です。ホワイトリストを設定してから再実行してください。' >&2
+  exit 2
+fi
+
+readonly LOCK_DIR="${REPO_ROOT}/${ACE_SUBAGENT_LOCK_DIR_RELATIVE}"
+readonly LOCK_INSTANCE="${LOCK_DIR}/${ACE_LOCK_INSTANCE_DIR_NAME}"
+mkdir -p "$LOCK_DIR"
+
+if ! mkdir "$LOCK_INSTANCE" 2>/dev/null; then
+  echo 'ace-capture: 別プロセスが実行中のためスキップします。' >&2
+  exit 0
+fi
+
+release_lock() {
+  rmdir "$LOCK_INSTANCE" 2>/dev/null || true
+}
+trap release_lock EXIT
+
+readonly WT_PARENT="${REPO_ROOT}/${ACE_WORKTREE_PARENT_RELATIVE}"
+mkdir -p "$WT_PARENT"
+readonly WT_NAME="${ACE_WORKTREE_DIR_PREFIX}$(date +%s)"
+readonly WT_PATH="${WT_PARENT}/${WT_NAME}"
+readonly BRANCH_BASE="${ACE_CAPTURE_BASE_BRANCH:-develop}"
+
+git worktree add -b "$WT_NAME" "$WT_PATH" "$BRANCH_BASE"
+
+remove_worktree() {
+  git worktree remove --force "$WT_PATH" >/dev/null 2>&1 || true
+}
+
+if [[ "${ACE_KEEP_WORKTREE:-0}" == "1" ]]; then
+  trap release_lock EXIT
+else
+  trap 'remove_worktree; release_lock' EXIT
+fi
+
+echo "ace-capture: worktree を作成しました: $WT_PATH"
+
+if [[ -n "${ACE_CLAUDE_CMD:-}" ]]; then
+  echo 'ace-capture: ACE_CLAUDE_CMD を実行します（同期）。実運用では nohup … disown への置換を推奨します。'
+  (
+    cd "$WT_PATH"
+    export ACE_CAPTURE_WORKTREE="$WT_PATH"
+    export ACE_GARDEN_WALL_PATHS
+    bash -c "$ACE_CLAUDE_CMD"
+  )
+else
+  echo 'ace-capture: ACE_CLAUDE_CMD が未設定のため、コマンドはスキップされました。'
+  echo '  例: export ACE_CLAUDE_CMD='\''claude -p --agent ace-capture --permission-mode bypassPermissions "..."'\'''
+fi
+
+if [[ "${ACE_KEEP_WORKTREE:-0}" == "1" ]]; then
+  echo "ace-capture: ACE_KEEP_WORKTREE=1 のため worktree を残します: $WT_PATH"
+fi

--- a/docs/ACE_FRAMEWORK.md
+++ b/docs/ACE_FRAMEWORK.md
@@ -10,6 +10,7 @@ tags: [ace, knowledge-management, playbook, ai-driven, context-engineering]
 references:
   - docs-template/08-knowledge/PLAYBOOK.md
   - docs-template/05-operations/deployment/ace-cycle.md
+  - docs-template/05-operations/deployment/ace-autonomous.md
   - docs-template/05-operations/deployment/knowledge-management.md
   - docs/ACE_SETUP.md
 changeImpact: high
@@ -21,6 +22,7 @@ changeImpact: high
 > - [Playbook テンプレート](../docs-template/08-knowledge/PLAYBOOK.md) - ACE Playbook のテンプレートファイル
 > - [ACE サイクル運用手順](../docs-template/05-operations/deployment/ace-cycle.md) - Generate → Reflect → Curate の具体手順
 > - [ナレッジ管理](../docs-template/05-operations/deployment/knowledge-management.md) - GitHub Discussions ベースのナレッジ管理
+> - [ACE autonomous](../docs-template/05-operations/deployment/ace-autonomous.md) - マージ後キャプチャの subagent + worktree（任意）
 
 ## 目次
 

--- a/docs/CASE_STUDIES.md
+++ b/docs/CASE_STUDIES.md
@@ -1,0 +1,16 @@
+# ケーススタディ
+
+本リポジトリのフレームワークや関連ツールを、実プロダクトでどのように運用したかを記録します。
+
+## ACE autonomous（FeelFlow ID Platform ほか）
+
+**ステータス**: データ収集中（shadow 運用完了後に追記予定）
+
+FeelFlow ID Platform 等で、ACE Playbook の自動ナレッジキャプチャを subagent + 独立 worktree に委譲した事例について、次を追記予定です。
+
+- shadow 運用期間と本番化の判断基準
+- 成功率（draft PR 採択率、自動 squash マージまで至った割合）
+- ロールバック発生件数と主因
+- Copilot / レビュー API クォータへの影響（採用した場合）
+
+参照テンプレート: [ace-autonomous.md](../docs-template/05-operations/deployment/ace-autonomous.md) · Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,48 @@
       "license": "MIT",
       "devDependencies": {
         "husky": "^9.1.0",
-        "markdownlint-cli2": "^0.20.0"
+        "markdownlint-cli2": "^0.20.0",
+        "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -54,6 +92,280 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -67,6 +379,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -76,6 +417,20 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/katex": {
       "version": "0.16.8",
@@ -98,6 +453,119 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -118,6 +586,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -129,6 +607,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -174,6 +662,13 @@
         "node": ">= 12"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -216,6 +711,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -241,6 +746,33 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -281,6 +813,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -474,6 +1021,267 @@
         "katex": "cli.js"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -482,6 +1290,16 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -1139,6 +1957,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -1172,6 +2020,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1183,6 +2045,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/punycode.js": {
@@ -1227,6 +2118,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -1251,6 +2176,13 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -1263,6 +2195,30 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.1.0",
@@ -1297,6 +2253,82 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1309,6 +2341,14 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
@@ -1328,6 +2368,217 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "npm --prefix mcp run check",
     "build:mcp": "npm --prefix mcp run build",
     "build:spec-index": "node scripts/build-spec-index.mjs",
-    "test": "npm --prefix mcp test",
+    "test": "npm --prefix mcp test && npm run test:ace-scripts",
+    "test:ace-scripts": "vitest run",
     "ace:check-playbook-categories": "npx --yes tsx docs-template/scripts/ace/check-category-size.ts docs-template/08-knowledge/PLAYBOOK.md",
     "setup:labels": "bash scripts/setup-github-labels.sh",
     "obsidian:sync": "node scripts/obsidian-sync.mjs",
@@ -19,7 +20,8 @@
   },
   "devDependencies": {
     "husky": "^9.1.0",
-    "markdownlint-cli2": "^0.20.0"
+    "markdownlint-cli2": "^0.20.0",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:mcp": "npm --prefix mcp run build",
     "build:spec-index": "node scripts/build-spec-index.mjs",
     "test": "npm --prefix mcp test",
+    "ace:check-playbook-categories": "npx --yes tsx docs-template/scripts/ace/check-category-size.ts docs-template/08-knowledge/PLAYBOOK.md",
     "setup:labels": "bash scripts/setup-github-labels.sh",
     "obsidian:sync": "node scripts/obsidian-sync.mjs",
     "obsidian:setup": "bash scripts/setup-obsidian-hook.sh",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["docs-template/scripts/ace/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## 概要

Closes #367

ACE ナレッジキャプチャを subagent + worktree で autonomous 化する**推奨テンプレ**と運用ドキュメントを追加します。

## 変更内容

- `docs-template/05-operations/deployment/ace-autonomous.md` — 実行モデル、feature flag、garden wall、4 ガード、shadow 運用
- `docs-template/scripts/ace/` — `run-subagent.sh`、`check-category-size.ts`、README
- `docs-template/.claude/agents/ace-capture.md`、`post-merge.ace.sample.sh`
- README・DEPLOYMENT 索引・ace-cycle・knowledge-management・ACE_FRAMEWORK へのリンク
- `/init-docs`・`/setup-ai-config` に任意の案内ステップを追加
- `docs/CASE_STUDIES.md`（FFID 等のメトリクス追記枠）
- `npm run ace:check-playbook-categories`、`vitest` による `check-category-size` の単体テスト、CI で `test:ace-scripts` 実行

## レビュー反映（追記コミット）

- PR 本文を `Closes #367` に統一（マージで Issue を閉じる）
- `post-merge.ace.sample.sh` が `.ace-capture/hook-env.sh` を `source` するように変更
- `ace-autonomous.md` に hook 環境変数・ロック腐敗の手順を追記
- `ACE_MAX_ENTRIES_PER_CATEGORY` 無効時に stderr へ警告
- ACE 見出し正規表現を `\d{3,}` に拡張（4 桁以上の ID に対応）

## 検証

- `npm test`（MCP + `test:ace-scripts`）
- `npm run ace:check-playbook-categories`
- `npm run lint:md`
- `npm run check`（MCP）
