### PR TITLE
docs: Cursor向けにGit Workflowを反映しMASTER参照を統一

### DIFF
--- a/.claude/commands/setup-ai-config.md
+++ b/.claude/commands/setup-ai-config.md
@@ -83,6 +83,18 @@ AskUserQuestion を使用して、どのツール向けの設定を生成する�
 ## Architecture
 [ARCHITECTURE.md からの要約]
 
+## Git Workflow (Mandatory)
+[docs/05-operations/deployment/git-workflow.md から要約]
+- Issue → Branch → Implement → Self-Review → PR → Merge
+- Branch naming and commit message format
+- PR requirements (self-review/test/issue link)
+
+## Self-Review Checklist
+[docs/05-operations/deployment/self-review.md から要約]
+
+## Out-of-Scope Issues
+- Create issue immediately and continue current task
+
 ## Important Rules
 - Always read docs/MASTER.md first for project context
 - Follow the coding standards in docs/03-implementation/PATTERNS.md

--- a/.claude/commands/setup-ai-config.md
+++ b/.claude/commands/setup-ai-config.md
@@ -85,15 +85,15 @@ AskUserQuestion を使用して、どのツール向けの設定を生成する�
 
 ## Git Workflow (Mandatory)
 [docs/05-operations/deployment/git-workflow.md から要約]
-- Issue → Branch → Implement → Self-Review → PR → Merge
-- Branch naming and commit message format
-- PR requirements (self-review/test/issue link)
+- Issue 起票から着手し、ブランチ → 実装 → セルフレビュー → PR → マージの順で進める
+- ブランチ命名規約とコミットメッセージ形式を守る
+- PR にはセルフレビュー結果・テスト結果・Issue リンク（例: `Closes #123`）を含める
 
 ## Self-Review Checklist
 [docs/05-operations/deployment/self-review.md から要約]
 
 ## Out-of-Scope Issues
-- Create issue immediately and continue current task
+- スコープ外の問題は即座に Issue を起票し、現行タスクは継続する（スコープ拡大はしない）
 
 ## Important Rules
 - Always read docs/MASTER.md first for project context

--- a/.cursorrules
+++ b/.cursorrules
@@ -65,6 +65,47 @@ This is an AI-driven development project starting with a core 7-document structu
 2. **Phase 2: Extension** - Additional features
 3. **Phase 3: Optimization** - Performance and scalability
 
+## Git Workflow (Mandatory)
+
+Always start from an Issue and follow the full flow:
+
+1. **Create Issue** - `gh issue create --title "..." --body "..."`
+2. **Create Branch** - `git checkout -b feature/#{issue-number}-{description}` (from `develop`)
+3. **Implement** - Follow `docs-template/MASTER.md` constraints
+4. **Self-Review** - Run checklist before PR
+5. **Run Tests** - lint / type-check / test must pass
+6. **Commit** - `<type>: #<issue> <subject>`
+7. **Create PR** - `gh pr create --base develop`
+8. **Merge & Cleanup** - Squash merge, return to `develop`, delete feature branch
+
+### Branch Naming
+- `feature/#{issue}-{description}` for features
+- `fix/#{issue}-{description}` for bug fixes
+- `chore/#{issue}-{description}` for maintenance
+
+### Commit Message Format
+`<type>: #<issue> <subject>`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+### PR Requirements
+- Include self-review results
+- Include test results
+- Link issue with `Closes #<issue-number>`
+
+## Self-Review Checklist (Before PR)
+1. DRY: no duplicate logic/imports/magic numbers
+2. Code Quality: strict typing, error handling, naming, no debug logs
+3. Imports: sorted and no unused imports
+4. Tests: added/updated and all pass
+5. Automation: lint/build/hooks pass
+
+## Out-of-Scope Issues
+If you find an out-of-scope problem while working:
+1. Create a GitHub Issue immediately
+2. Do not expand scope in current task
+3. Continue current task and reference the new issue in PR when needed
+
 ## Code Generation Rules
 
 ### Before Generating Code

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,7 +1,7 @@
 # Cursor Rules for AI Spec-Driven Development
 
 ## 🚨 MANDATORY: Read MASTER.md First
-Before generating any code, you MUST read and understand `docs/MASTER.md`.
+Before generating any code, you MUST read and understand `docs-template/MASTER.md`.
 
 ## Project Context
 This is an AI-driven development project starting with a core 7-document structure optimized for AI tools, extensible as the project grows. The project emphasizes "less is more" - beginning with fewer, highly-focused documents that AI can effectively parse, then adding documents as needed.
@@ -67,6 +67,8 @@ This is an AI-driven development project starting with a core 7-document structu
 
 ## Git Workflow (Mandatory)
 
+運用の詳細は `docs/AI_GIT_WORKFLOW.md`（本リポジトリの手順）。テンプレ側の展開例は `docs-template/05-operations/deployment/git-workflow.md` を参照。
+
 Always start from an Issue and follow the full flow:
 
 1. **Create Issue** - `gh issue create --title "..." --body "..."`
@@ -109,10 +111,10 @@ If you find an out-of-scope problem while working:
 ## Code Generation Rules
 
 ### Before Generating Code
-1. Read `docs/MASTER.md` for project context
-2. Check `docs/03-implementation/PATTERNS.md` for implementation patterns
-3. Verify `docs/02-design/ARCHITECTURE.md` for technical decisions
-4. Review `docs/02-design/DOMAIN.md` for business logic
+1. Read `docs-template/MASTER.md` for project context
+2. Check `docs-template/03-implementation/PATTERNS.md` for implementation patterns
+3. Verify `docs-template/02-design/ARCHITECTURE.md` for technical decisions
+4. Review `docs-template/02-design/DOMAIN.md` for business logic
 
 ### During Code Generation
 1. Follow the coding rules from MASTER.md
@@ -158,14 +160,15 @@ When generating code, always include this constraint:
 ```
 
 ## Document References
-- `docs/MASTER.md` - Project overview and rules
-- `docs/01-context/PROJECT.md` - Business requirements
-- `docs/02-design/ARCHITECTURE.md` - Technical architecture
-- `docs/02-design/DOMAIN.md` - Business logic
-- `docs/03-implementation/PATTERNS.md` - Implementation patterns
-- `docs/04-quality/TESTING.md` - Testing strategies
-- `docs/05-operations/DEPLOYMENT.md` - Deployment procedures
-- `docs/08-knowledge/` - Knowledge base and best practices
+- `docs-template/MASTER.md` - Project overview and rules
+- `docs-template/01-context/PROJECT.md` - Business requirements
+- `docs-template/02-design/ARCHITECTURE.md` - Technical architecture
+- `docs-template/02-design/DOMAIN.md` - Business logic
+- `docs-template/03-implementation/PATTERNS.md` - Implementation patterns
+- `docs-template/04-quality/TESTING.md` - Testing strategies
+- `docs-template/05-operations/DEPLOYMENT.md` - Deployment procedures
+- `docs-template/08-knowledge/` - Knowledge base and best practices
+- `docs/AI_GIT_WORKFLOW.md` - Issue-first Git workflow for this repository
 
 ## Code Review Checklist
 - [ ] MASTER.md rules followed
@@ -178,4 +181,4 @@ When generating code, always include this constraint:
 - [ ] Naming conventions followed
 - [ ] Constants properly organized by layer
 
-Remember: Always reference MASTER.md for project-specific requirements and constraints.
+Remember: Always reference `docs-template/MASTER.md` for project-specific requirements and constraints.

--- a/docs-template/SETUP_CURSOR.md
+++ b/docs-template/SETUP_CURSOR.md
@@ -158,6 +158,8 @@ This is an AI-driven development project starting with a core 7-document structu
 
 ## Git Workflow (Mandatory)
 
+手順の詳細（テンプレ）: `docs-template/05-operations/deployment/git-workflow.md`
+
 Always start from an Issue and follow the full flow:
 
 1. **Create Issue** - `gh issue create --title "..." --body "..."`

--- a/docs-template/SETUP_CURSOR.md
+++ b/docs-template/SETUP_CURSOR.md
@@ -156,6 +156,47 @@ This is an AI-driven development project starting with a core 7-document structu
 2. **Phase 2: Extension** - Additional features
 3. **Phase 3: Optimization** - Performance and scalability
 
+## Git Workflow (Mandatory)
+
+Always start from an Issue and follow the full flow:
+
+1. **Create Issue** - `gh issue create --title "..." --body "..."`
+2. **Create Branch** - `git checkout -b feature/#{issue-number}-{description}` (from `develop`)
+3. **Implement** - Follow `docs-template/MASTER.md` constraints
+4. **Self-Review** - Run checklist before PR
+5. **Run Tests** - lint / type-check / test must pass
+6. **Commit** - `<type>: #<issue> <subject>`
+7. **Create PR** - `gh pr create --base develop`
+8. **Merge & Cleanup** - Squash merge, return to `develop`, delete feature branch
+
+### Branch Naming
+- `feature/#{issue}-{description}` for features
+- `fix/#{issue}-{description}` for bug fixes
+- `chore/#{issue}-{description}` for maintenance
+
+### Commit Message Format
+`<type>: #<issue> <subject>`
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+### PR Requirements
+- Include self-review results
+- Include test results
+- Link issue with `Closes #<issue-number>`
+
+## Self-Review Checklist (Before PR)
+1. DRY: no duplicate logic/imports/magic numbers
+2. Code Quality: strict typing, error handling, naming, no debug logs
+3. Imports: sorted and no unused imports
+4. Tests: added/updated and all pass
+5. Automation: lint/build/hooks pass
+
+## Out-of-Scope Issues
+If you find an out-of-scope problem while working:
+1. Create a GitHub Issue immediately
+2. Do not expand scope in current task
+3. Continue current task and reference the new issue in PR when needed
+
 ## Code Generation Rules
 
 ### Before Suggesting Code

--- a/docs/AI_CONFIG_BEST_PRACTICES.md
+++ b/docs/AI_CONFIG_BEST_PRACTICES.md
@@ -93,7 +93,8 @@ AIはデフォルトでは「コードを書いて終わり」の振る舞いに
 
 - **CLAUDE.md**: Claude Codeはマルチターン対話が得意。Taskツールの活用指示も記載するとよい
 - **AGENTS.md**: 全エージェント共通のため、ツール固有の指示は省略し汎用的に記載
-- **copilot-instructions.md / .cursorrules**: コード補完が主用途のため、このセクションは省略してもよい
+- **copilot-instructions.md**: コード補完が主用途のため、このセクションは省略してもよい
+- **.cursorrules**: 補完用途に加えComposer/AgentでGit操作も発生するため、最低限の作業スタイルとGit Workflowを含める
 
 ---
 
@@ -422,12 +423,15 @@ GitHub Copilotはコード補完とPRレビューが主用途です。作業ス�
 
 ### .cursorrules
 
-Cursorはエディタ内でのコード補完とチャットが主用途です。CLAUDE.mdに近い記載が可能ですが、マルチターン対話の深さはやや劣るため、ルールを簡潔にします。
+Cursorはエディタ内でのコード補完とチャットが主用途ですが、Composer/Agent実行時はGit操作まで自律的に行うため、Git Workflowとセルフレビュー要件も必ず含めます。
 
 - [x] MASTER.md必須参照ルール
 - [x] 情報確認プロトコル
 - [x] Key Constraints テーブル
 - [x] 命名規則テーブル
+- [x] **Git Workflow**（Issue/Branch/PR）
+- [x] **セルフレビューチェックリスト**
+- [x] **スコープ外問題の取り扱い**
 - [x] コード生成ルール
 - [x] 参照ドキュメント一覧
 


### PR DESCRIPTION
## 概要
- `.cursorrules` に Issue→Branch→PR までの必須 Git Workflow を追加
- 本リポジトリでは `docs/MASTER.md` が存在しないため、必読・参照パスを `docs-template/` に統一
- Git 手順の SSOT として `docs/AI_GIT_WORKFLOW.md` / `docs-template/05-operations/deployment/git-workflow.md` を明記
- `docs-template/SETUP_CURSOR.md` と `.claude/commands/setup-ai-config.md` を追随（生成テンプレの体裁を日本語に揃え）

## セルフレビュー
- [x] 変更はドキュメント・ルールのみ（実行コードなし）
- [x] `docs-template` 配下の参照パスは実在ファイルと整合

Squash merge を想定しています。

Made with [Cursor](https://cursor.com)