### PR TITLE
chore: #408 docs-template ファイル名命名規則の統一と README 新設

### DIFF
--- a/docs-template/05-operations/deployment/ai-tools-integration.md
+++ b/docs-template/05-operations/deployment/ai-tools-integration.md
@@ -466,7 +466,7 @@ branches:
 
 - [DEPLOYMENT.md](../DEPLOYMENT.md) - デプロイメント戦略全体
 - [multi-cli-review-orchestration.md](./multi-cli-review-orchestration.md) - Multi-CLI レビューオーケストレーション
-- [REVIEW-AGENT-CREATION-GUIDE.md](../../06-reference/REVIEW-AGENT-CREATION-GUIDE.md) - 汎用レビューエージェント作成ガイド
+- [REVIEW_AGENT_CREATION_GUIDE.md](../../06-reference/REVIEW_AGENT_CREATION_GUIDE.md) - 汎用レビューエージェント作成ガイド
 - [SETUP_CLAUDE_CODE.md](../../SETUP_CLAUDE_CODE.md) - Claude Code詳細設定
 - [SETUP_GITHUB_COPILOT.md](../../SETUP_GITHUB_COPILOT.md) - GitHub Copilot詳細設定
 - [SETUP_CURSOR.md](../../SETUP_CURSOR.md) - Cursor詳細設定

--- a/docs-template/05-operations/deployment/cursor-cli-reviewer.md
+++ b/docs-template/05-operations/deployment/cursor-cli-reviewer.md
@@ -197,7 +197,7 @@ Error: Not authenticated
 ## 関連ドキュメント
 
 - [multi-cli-review-orchestration.md](./multi-cli-review-orchestration.md) — オーケストレーション運用ガイド
-- [REVIEW-AGENT-CREATION-GUIDE.md](../../06-reference/REVIEW-AGENT-CREATION-GUIDE.md) — 汎用レビューエージェント作成ガイド
+- [REVIEW_AGENT_CREATION_GUIDE.md](../../06-reference/REVIEW_AGENT_CREATION_GUIDE.md) — 汎用レビューエージェント作成ガイド
 - [ai-tools-integration.md](./ai-tools-integration.md) — AIツール統合・コスト比較
 - [gemini-cli-reviewer.md](./gemini-cli-reviewer.md) — Gemini CLI セットアップ
 - [SETUP_CURSOR.md](../../SETUP_CURSOR.md) — Cursor エディタ詳細設定

--- a/docs-template/05-operations/deployment/gemini-cli-reviewer.md
+++ b/docs-template/05-operations/deployment/gemini-cli-reviewer.md
@@ -185,6 +185,6 @@ Error: 429 Too Many Requests
 ## 関連ドキュメント
 
 - [multi-cli-review-orchestration.md](./multi-cli-review-orchestration.md) — オーケストレーション運用ガイド
-- [REVIEW-AGENT-CREATION-GUIDE.md](../../06-reference/REVIEW-AGENT-CREATION-GUIDE.md) — 汎用レビューエージェント作成ガイド
+- [REVIEW_AGENT_CREATION_GUIDE.md](../../06-reference/REVIEW_AGENT_CREATION_GUIDE.md) — 汎用レビューエージェント作成ガイド
 - [ai-tools-integration.md](./ai-tools-integration.md) — AIツール統合・コスト比較
 - [cursor-cli-reviewer.md](./cursor-cli-reviewer.md) — Cursor CLI セットアップ

--- a/docs-template/05-operations/deployment/multi-cli-review-orchestration.md
+++ b/docs-template/05-operations/deployment/multi-cli-review-orchestration.md
@@ -439,9 +439,9 @@ Cross-Modelモードで異なるCLIが矛盾する結果を返した場合：
 
 ## 関連ドキュメント
 
-- [REVIEW-AGENT-CREATION-GUIDE.md](../../06-reference/REVIEW-AGENT-CREATION-GUIDE.md) — 汎用レビューエージェント作成ガイド
+- [REVIEW_AGENT_CREATION_GUIDE.md](../../06-reference/REVIEW_AGENT_CREATION_GUIDE.md) — 汎用レビューエージェント作成ガイド
 - [ai-tools-integration.md](./ai-tools-integration.md) — AIツール統合・コスト比較
 - [git-workflow.md](./git-workflow.md) — AI駆動Git Workflow
 - [gemini-cli-reviewer.md](./gemini-cli-reviewer.md) — Gemini CLI セットアップ
 - [cursor-cli-reviewer.md](./cursor-cli-reviewer.md) — Cursor CLI セットアップ
-- [COPILOT-AGENTS.md](../../06-reference/COPILOT-AGENTS.md) — Copilot エージェント定義
+- [COPILOT_AGENTS.md](../../06-reference/COPILOT_AGENTS.md) — Copilot エージェント定義

--- a/docs-template/06-reference/COPILOT_AGENTS.md
+++ b/docs-template/06-reference/COPILOT_AGENTS.md
@@ -742,10 +742,10 @@ PR作成後に `@review-router` を呼び出すだけで、変更内容を自動
 
 ## 関連ドキュメント
 
-- [REVIEW-AGENT-CREATION-GUIDE.md](./REVIEW-AGENT-CREATION-GUIDE.md) - 汎用レビューエージェント作成ガイド（ツール非依存のパースペクティブ定義・アダプターパターン）
+- [REVIEW_AGENT_CREATION_GUIDE.md](./REVIEW_AGENT_CREATION_GUIDE.md) - 汎用レビューエージェント作成ガイド（ツール非依存のパースペクティブ定義・アダプターパターン）
 - [multi-cli-review-orchestration.md](../05-operations/deployment/multi-cli-review-orchestration.md) - Multi-CLI レビューオーケストレーション（5 CLI統合運用）
 - [MASTER.md](../MASTER.md) - プロジェクト全体の設定
 - [PATTERNS.md](../03-implementation/PATTERNS.md) - 実装パターン
 - [TESTING.md](../04-quality/TESTING.md) - テスト戦略
 
-> **💡 Note**: 本ドキュメントのエージェントテンプレートはGitHub Copilot固有ですが、ツール非依存の汎用パターンについては [REVIEW-AGENT-CREATION-GUIDE.md](./REVIEW-AGENT-CREATION-GUIDE.md) を参照してください。同ガイドでは、本ドキュメントの6エージェントを含む7つの標準パースペクティブを5つのAI CLI（Claude Code、Codex、Copilot、Gemini、Cursor）で統一的に管理する方法を定義しています。
+> **💡 Note**: 本ドキュメントのエージェントテンプレートはGitHub Copilot固有ですが、ツール非依存の汎用パターンについては [REVIEW_AGENT_CREATION_GUIDE.md](./REVIEW_AGENT_CREATION_GUIDE.md) を参照してください。同ガイドでは、本ドキュメントの6エージェントを含む7つの標準パースペクティブを5つのAI CLI（Claude Code、Codex、Copilot、Gemini、Cursor）で統一的に管理する方法を定義しています。

--- a/docs-template/06-reference/REVIEW_AGENT_CREATION_GUIDE.md
+++ b/docs-template/06-reference/REVIEW_AGENT_CREATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Review Agent Creation Guide
 
-> **Parent**: [COPILOT-AGENTS.md](./COPILOT-AGENTS.md) | [ai-tools-integration.md](../05-operations/deployment/ai-tools-integration.md)
+> **Parent**: [COPILOT_AGENTS.md](./COPILOT_AGENTS.md) | [ai-tools-integration.md](../05-operations/deployment/ai-tools-integration.md)
 
 ## 概要
 
@@ -520,7 +520,7 @@ bash scripts/multi-review.sh --mode cross-model --perspective code-review
 
 - [ ] `ai-tools-integration.md` の比較テーブルに追加
 - [ ] CLI固有のセットアップガイドを作成（`{cli}-reviewer.md`）
-- [ ] `COPILOT-AGENTS.md` の対応表を更新（該当する場合）
+- [ ] `COPILOT_AGENTS.md` の対応表を更新（該当する場合）
 
 ### Step 5: テスト
 
@@ -532,7 +532,7 @@ bash scripts/multi-review.sh --mode cross-model --perspective code-review
 
 ## 関連ドキュメント
 
-- [COPILOT-AGENTS.md](./COPILOT-AGENTS.md) — GitHub Copilot エージェント定義
+- [COPILOT_AGENTS.md](./COPILOT_AGENTS.md) — GitHub Copilot エージェント定義
 - [ai-tools-integration.md](../05-operations/deployment/ai-tools-integration.md) — AIツール統合ガイド
 - [multi-cli-review-orchestration.md](../05-operations/deployment/multi-cli-review-orchestration.md) — オーケストレーション運用ガイド
 - [gemini-cli-reviewer.md](../05-operations/deployment/gemini-cli-reviewer.md) — Gemini CLI セットアップ

--- a/docs-template/MASTER.md
+++ b/docs-template/MASTER.md
@@ -256,12 +256,14 @@ AIが生成したドキュメント・コードは、以下のタイミングで
   - 形式: `数字-英語小文字（ハイフン区切り）`
   - 例: `01-context`, `02-design`, `03-implementation`
 - **ファイル名**:
-  - メインドキュメント: `英語大文字.md`（AI識別性優先）
-  - 例: `MASTER.md`, `ARCHITECTURE.md`, `TESTING.md`
+  - メインドキュメント: `UPPER_SNAKE_CASE.md`（AI識別性優先・複数語はアンダースコア `_` 区切り）
+  - 例: `MASTER.md`, `ARCHITECTURE.md`, `LESSONS_LEARNED.md`, `DEVELOPMENT_PREPARATION.md`
+  - サブフォルダ内ファイル: `lowercase-with-hyphens.md`（例: `git-workflow.md`, `phased-rollout.md`）
+  - 詳細・適用条件・逸脱判断は [README.md](./README.md#-ファイル名命名規則) を SSOT とする
 - **禁止事項**:
   - ❌ 日本語ファイル名
   - ❌ スペースを含むファイル名
-  - ❌ アンダースコア区切り（ハイフンを使用）
+  - ❌ メインドキュメントでのハイフン区切り（複数語は `UPPER_SNAKE_CASE.md` を使用）
   - ❌ ファイル名への番号プレフィックス（ディレクトリのみ使用）
 
 - **例外**:
@@ -518,7 +520,7 @@ metrics:
 - [06-reference/DEVELOPMENT_PREPARATION.md](./06-reference/DEVELOPMENT_PREPARATION.md) - 開発準備ガイド（5 Phases: Issue-First → Document-Driven → MECE検証 → AI Spec-Driven → Git Workflow）
 - [00-planning/POC_WORKFLOW.md](./00-planning/POC_WORKFLOW.md) - PoCワークフロー・結果記録テンプレート・仕様マッピングガイド
 - [06-reference/DECISION_MATRIX.md](./06-reference/DECISION_MATRIX.md) - 「どの文書に書く？」判断ガイド（Decision Matrix・曖昧ケース例・機能×文書マトリクス）
-- [06-reference/COPILOT-AGENTS.md](./06-reference/COPILOT-AGENTS.md) - GitHub Copilot Agents設定リファレンス（6種のレビューエージェントテンプレート）
+- [06-reference/COPILOT_AGENTS.md](./06-reference/COPILOT_AGENTS.md) - GitHub Copilot Agents設定リファレンス（6種のレビューエージェントテンプレート）
 - [05-operations/ORGANIZATIONAL_ROLLOUT.md](./05-operations/ORGANIZATIONAL_ROLLOUT.md) - 組織展開ガイド索引（段階的導入の Phase 1〜4・文書分割・アーカイブ・月次ヘルスチェック）
 
 ## ドキュメント構造ガイド（AIツール向け）
@@ -537,6 +539,16 @@ metrics:
 ユーザー: 「セルフレビューの方法を教えて」
 AI: DEPLOYMENT.md（索引）→ deployment/self-review.md を読み込み
 ```
+
+### ファイル名命名規則
+
+| 階層                                   | ルール                      | 例                                       |
+| -------------------------------------- | --------------------------- | ---------------------------------------- |
+| ルート直下 / 番号付きフォルダ直下の MD | `UPPER_SNAKE_CASE.md`       | `MASTER.md`, `DEPLOYMENT.md`             |
+| サブフォルダ名                         | `lowercase-with-hyphens/`   | `deployment/`, `organizational-rollout/` |
+| サブフォルダ内 MD                      | `lowercase-with-hyphens.md` | `git-workflow.md`, `phased-rollout.md`   |
+
+> **詳細・適用条件・逸脱判断**: [docs-template/README.md](./README.md#-ファイル名命名規則) を SSOT とする。
 
 ### ファイルサイズの閾値（書籍 第14章準拠）
 

--- a/docs-template/MASTER.md
+++ b/docs-template/MASTER.md
@@ -542,13 +542,11 @@ AI: DEPLOYMENT.md（索引）→ deployment/self-review.md を読み込み
 
 ### ファイル名命名規則
 
-| 階層                                   | ルール                      | 例                                       |
-| -------------------------------------- | --------------------------- | ---------------------------------------- |
-| ルート直下 / 番号付きフォルダ直下の MD | `UPPER_SNAKE_CASE.md`       | `MASTER.md`, `DEPLOYMENT.md`             |
-| サブフォルダ名                         | `lowercase-with-hyphens/`   | `deployment/`, `organizational-rollout/` |
-| サブフォルダ内 MD                      | `lowercase-with-hyphens.md` | `git-workflow.md`, `phased-rollout.md`   |
+ファイル名命名規則の SSOT は [docs-template/README.md](./README.md#-ファイル名命名規則) です。短縮版:
 
-> **詳細・適用条件・逸脱判断**: [docs-template/README.md](./README.md#-ファイル名命名規則) を SSOT とする。
+- ルート直下 / 番号付きフォルダ直下の MD: `UPPER_SNAKE_CASE.md`（例: `MASTER.md`, `DEPLOYMENT.md`）
+- サブフォルダ名・サブフォルダ内 MD: `lowercase-with-hyphens(.md)`（例: `deployment/git-workflow.md`）
+- 例外（`README.md`, `CLAUDE.md` 等）・逸脱判断・新規追加チェックリストは SSOT を参照
 
 ### ファイルサイズの閾値（書籍 第14章準拠）
 

--- a/docs-template/README.md
+++ b/docs-template/README.md
@@ -1,40 +1,49 @@
 # docs-template/
 
-AI 仕様駆動開発フレームワークの **テンプレート集**。コア 7 文書を起点に、プロジェクト規模に応じて拡張フォルダを追加していく構成です。
+AI 仕様駆動開発フレームワークの **テンプレート集**。本ドキュメントは **テンプレ内の規約** に焦点を絞った SSOT です。
 
-> **使い方の概観**: ルート [README.md](../README.md) の「導入方法」セクションを参照。本 README は **テンプレ内の規約** に焦点を絞ります。
+> **使い方の概観**: ルート [README.md](../README.md) の「導入方法」セクションを参照。
+>
+> **「コア 7 文書」の正しい定義**: 本フレームワークの「コア 7 文書」は `MASTER.md` / `PROJECT.md` / `ARCHITECTURE.md` / `DOMAIN.md` / `PATTERNS.md` / `TESTING.md` / `DEPLOYMENT.md` の 7 ファイルを指し、番号付きフォルダ（`01-context/` 等）配下に分散配置されています。詳細はルートの [CLAUDE.md](../CLAUDE.md) と [MASTER.md](./MASTER.md) を参照。
 
 ---
 
 ## 📂 構成
 
-### コア 7 文書 + ルート直下
+### ルート直下のセットアップ系ドキュメント
 
 ```
 docs-template/
-├── MASTER.md                          # 中央ハブ。全体方針・AI ルール・ツール統合
-├── GETTING_STARTED.md                 # 標準セットアップ手順
-├── GETTING_STARTED_NEW_PROJECT.md     # 新規プロジェクト向け
+├── MASTER.md                            # 中央ハブ（コア 7 文書のひとつ）
+├── README.md                            # 本ファイル（テンプレ規約 SSOT）
+├── GETTING_STARTED.md                   # 標準セットアップ手順
+├── GETTING_STARTED_NEW_PROJECT.md       # 新規プロジェクト向け
 ├── GETTING_STARTED_ABSOLUTE_BEGINNER.md # 初学者向け
-├── SETUP_CLAUDE_CODE.md               # Claude Code 詳細設定
-├── SETUP_CURSOR.md                    # Cursor 詳細設定
-└── SETUP_GITHUB_COPILOT.md            # GitHub Copilot 詳細設定
+├── SETUP_CLAUDE_CODE.md                 # Claude Code 詳細設定
+├── SETUP_CURSOR.md                      # Cursor 詳細設定
+└── SETUP_GITHUB_COPILOT.md              # GitHub Copilot 詳細設定
 ```
 
-### 番号付き拡張フォルダ
+> **注**: 上記ブロックは「ルート直下に置くセットアップ系」のみを示します。コア 7 文書の他の 6 つ（`PROJECT.md`, `ARCHITECTURE.md` 等）と拡張ドキュメントは下表の番号付きフォルダ配下にあります。
 
-| フォルダ                 | 役割                                                          |
-| ------------------------ | ------------------------------------------------------------- |
-| `00-planning/`           | 企画・PoC・インセプションデッキ                               |
-| `01-context/`            | プロジェクト背景・制約                                        |
-| `02-design/`             | アーキテクチャ・ドメイン・API・データベース                   |
-| `03-implementation/`     | 実装パターン・規約・依存ガイド・サンプルテンプレ              |
-| `04-quality/`            | テスト戦略・バリデーション・ガードレール・セキュリティ        |
-| `05-operations/`         | デプロイ・運用・組織展開（索引 + 詳細サブフォルダ構造）       |
-| `06-reference/`          | 用語集・意思決定ログ・エージェント定義                        |
-| `07-project-management/` | ロードマップ・タスク・リスク                                  |
-| `08-knowledge/`          | プレイブック・FAQ・ベストプラクティス・トラブルシューティング |
-| `archive/`               | 廃止文書の退避先                                              |
+### 拡張フォルダ
+
+| フォルダ                 | 役割                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `00-planning/`           | 企画・PoC・インセプションデッキ                                                |
+| `01-context/`            | プロジェクト背景・制約（コア: `PROJECT.md`）                                   |
+| `02-design/`             | アーキテクチャ・ドメイン・API・DB（コア: `ARCHITECTURE.md`, `DOMAIN.md`）      |
+| `03-implementation/`     | 実装パターン・規約・依存ガイド・サンプルテンプレ（コア: `PATTERNS.md`）        |
+| `04-quality/`            | テスト戦略・バリデーション・ガードレール・セキュリティ（コア: `TESTING.md`）   |
+| `05-operations/`         | デプロイ・運用・組織展開（コア: `DEPLOYMENT.md`、索引 + 詳細サブフォルダ構造） |
+| `06-reference/`          | 用語集・意思決定ログ・エージェント定義                                         |
+| `07-project-management/` | ロードマップ・タスク・リスク                                                   |
+| `08-knowledge/`          | プレイブック・FAQ・ベストプラクティス・トラブルシューティング                  |
+| `archive/`               | 廃止文書の退避先                                                               |
+| `setup-guides/`          | ツール別セットアップ詳細ガイド（GitHub Copilot 等の分割文書）                  |
+| `scripts/`               | ACE 等の運用スクリプト雛形                                                     |
+| `.claude/`               | Claude Code 用 hooks/skills 雛形                                               |
+| `.github/`               | エージェント定義・GitHub 設定雛形                                              |
 
 > **`05-operations/` の特殊構造**: 運用系は文書量が多いため、トップレベルの `DEPLOYMENT.md` / `ORGANIZATIONAL_ROLLOUT.md` を **索引** とし、`deployment/` / `organizational-rollout/` サブフォルダに詳細を配置するパターンを採用しています。詳細は [05-operations/organizational-rollout/document-splitting.md](./05-operations/organizational-rollout/document-splitting.md) の分割閾値（500/800/1200 行）を参照。
 
@@ -54,18 +63,37 @@ docs-template/
 
 ### 適用条件
 
-- **ハイフン (`-`) は使わない**: トップレベル MD はアンダースコア区切りで統一する（例: `REVIEW_AGENT_CREATION_GUIDE.md` であって `REVIEW-AGENT-CREATION-GUIDE.md` ではない）
+- **ハイフン (`-`) は使わない（メインドキュメント）**: トップレベル MD はアンダースコア区切りで統一する（例: `REVIEW_AGENT_CREATION_GUIDE.md` であって `REVIEW-AGENT-CREATION-GUIDE.md` ではない）
 - **拡張子**: Markdown は `.md`（`.markdown` は使わない）
-- **数字プレフィックス**: 番号付きフォルダ自体（`00-planning/` 等）には付与するが、サブフォルダ内ファイルには付けない（読み順は親索引の表で示す）
-- **大文字小文字**: トップレベル MD はファイル名全体を大文字、サブフォルダおよびその配下のファイルは全て小文字
+- **数字プレフィックス**: 番号付きフォルダ自体（`00-planning/` 等）には付与する。サブフォルダ内ファイルでは **原則付けない**（読み順は親索引の表で示す）が、**読み順を強く示したい複数パートの分割文書** では `0N-` プレフィックスを許容する（既存例: `08-knowledge/best-practices/0X-*.md`, `setup-guides/github-copilot/0X-*.md`）
+- **大文字小文字**: ルート直下 / 番号付きフォルダ直下の MD はファイル名全体を大文字、サブフォルダ名およびサブフォルダ内 MD は全て小文字（後述「例外」を除く）
+
+### 例外（規則に従わない既知のファイル）
+
+以下は **慣習・ツール都合** で規則と異なる命名を許容します。新規追加時にこのリストを拡張する場合は PR 説明欄で理由を明記してください。
+
+- `README.md` — Markdown プロジェクトの標準的慣習
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` — AI ツール向けの特殊ファイル（ファイル名がツール側で固定されている）
+- `.github/copilot-instructions.md` — GitHub Copilot が固定ファイル名を要求
+- `.cursorrules` — Cursor が固定ファイル名を要求
 
 ### 命名規則を逸脱したい場合
 
 逸脱には常に **トレードオフ** があります。次のいずれかに該当する場合のみ、PR 説明欄で理由を明記して逸脱を許容してください。
 
-- 公式 API/プロダクト名がハイフン区切りで広く認知されている
-- 既存のリンク互換性を維持する必要がある（外部からの参照が多い）
-- 自動生成ファイル（テンプレ展開 / lint 出力）
+- **公式 API/プロダクト名がハイフン区切りで広く認知されている場合**
+  - 例: `next.config.js`, `tsconfig.json` のような確立した命名はそのまま使用する（本テンプレ内では現状該当なし）
+- **既存のリンク互換性を維持する必要がある（外部からの参照が多い）**
+  - 例: 外部公開済みの URL（ブログ記事・プレゼン資料・他リポジトリの README）から直接リンクされており、リネームによって 404 が発生するファイル
+- **自動生成ファイル（テンプレ展開 / lint 出力）**
+  - 例: `mcp/dist/` 配下のビルド成果物、`scripts/` の lint 出力など、人手で命名しない成果物
+
+### 新規ファイル追加時のチェックリスト
+
+- [ ] 配置場所はルート直下 / 番号付きフォルダ直下 / サブフォルダ内のいずれか
+- [ ] 命名規則の適用階層に従っているか（規則表 を参照）
+- [ ] 例外（`README.md` 等）に該当しないことを確認したか
+- [ ] 逸脱する場合は PR 説明欄に該当条件と理由を記載したか
 
 ---
 
@@ -74,19 +102,23 @@ docs-template/
 ### 1. テンプレートをコピー
 
 ```bash
-# 例: 自プロジェクトの docs/ にコア 7 文書をコピー
+# 例: 自プロジェクトの docs/ にコア 7 文書を含む基本構造をコピー
 cp docs-template/MASTER.md your-project/docs/
-cp -r docs-template/01-context/ your-project/docs/
-cp -r docs-template/02-design/ your-project/docs/
-cp -r docs-template/03-implementation/ your-project/docs/
-cp -r docs-template/04-quality/ your-project/docs/
-cp -r docs-template/05-operations/ your-project/docs/
+cp -r docs-template/01-context/ your-project/docs/        # PROJECT.md を含む
+cp -r docs-template/02-design/ your-project/docs/         # ARCHITECTURE.md, DOMAIN.md を含む
+cp -r docs-template/03-implementation/ your-project/docs/ # PATTERNS.md を含む
+cp -r docs-template/04-quality/ your-project/docs/        # TESTING.md を含む
+cp -r docs-template/05-operations/ your-project/docs/     # DEPLOYMENT.md を含む
 cp -r docs-template/06-reference/ your-project/docs/
+
+# セットアップ系ガイドは必要に応じて選択コピー
+# cp docs-template/GETTING_STARTED.md your-project/docs/
+# cp docs-template/SETUP_*.md your-project/docs/
 ```
 
 ### 2. プレースホルダを埋める
 
-各テンプレ冒頭の YAML frontmatter（`title`, `version`, `status`, `owner`, `created`, `updated`）と、本文中の `{{プロジェクト名}}` 等を自プロジェクトの値に置換します。
+frontmatter を持つテンプレ（`MASTER.md` 等）の冒頭 YAML（`title`, `version`, `status`, `owner`, `created`, `updated`）と、本文中の `{{プロジェクト名}}` 等を自プロジェクトの値に置換します。frontmatter を持たないテンプレ（`GETTING_STARTED.md`, `SETUP_*.md` 等）は本文の置換のみ行ってください。
 
 ### 3. MCP サーバーで整合性チェック
 

--- a/docs-template/README.md
+++ b/docs-template/README.md
@@ -1,0 +1,106 @@
+# docs-template/
+
+AI 仕様駆動開発フレームワークの **テンプレート集**。コア 7 文書を起点に、プロジェクト規模に応じて拡張フォルダを追加していく構成です。
+
+> **使い方の概観**: ルート [README.md](../README.md) の「導入方法」セクションを参照。本 README は **テンプレ内の規約** に焦点を絞ります。
+
+---
+
+## 📂 構成
+
+### コア 7 文書 + ルート直下
+
+```
+docs-template/
+├── MASTER.md                          # 中央ハブ。全体方針・AI ルール・ツール統合
+├── GETTING_STARTED.md                 # 標準セットアップ手順
+├── GETTING_STARTED_NEW_PROJECT.md     # 新規プロジェクト向け
+├── GETTING_STARTED_ABSOLUTE_BEGINNER.md # 初学者向け
+├── SETUP_CLAUDE_CODE.md               # Claude Code 詳細設定
+├── SETUP_CURSOR.md                    # Cursor 詳細設定
+└── SETUP_GITHUB_COPILOT.md            # GitHub Copilot 詳細設定
+```
+
+### 番号付き拡張フォルダ
+
+| フォルダ                 | 役割                                                          |
+| ------------------------ | ------------------------------------------------------------- |
+| `00-planning/`           | 企画・PoC・インセプションデッキ                               |
+| `01-context/`            | プロジェクト背景・制約                                        |
+| `02-design/`             | アーキテクチャ・ドメイン・API・データベース                   |
+| `03-implementation/`     | 実装パターン・規約・依存ガイド・サンプルテンプレ              |
+| `04-quality/`            | テスト戦略・バリデーション・ガードレール・セキュリティ        |
+| `05-operations/`         | デプロイ・運用・組織展開（索引 + 詳細サブフォルダ構造）       |
+| `06-reference/`          | 用語集・意思決定ログ・エージェント定義                        |
+| `07-project-management/` | ロードマップ・タスク・リスク                                  |
+| `08-knowledge/`          | プレイブック・FAQ・ベストプラクティス・トラブルシューティング |
+| `archive/`               | 廃止文書の退避先                                              |
+
+> **`05-operations/` の特殊構造**: 運用系は文書量が多いため、トップレベルの `DEPLOYMENT.md` / `ORGANIZATIONAL_ROLLOUT.md` を **索引** とし、`deployment/` / `organizational-rollout/` サブフォルダに詳細を配置するパターンを採用しています。詳細は [05-operations/organizational-rollout/document-splitting.md](./05-operations/organizational-rollout/document-splitting.md) の分割閾値（500/800/1200 行）を参照。
+
+---
+
+## 📝 ファイル名命名規則
+
+テンプレ内のファイル名は **2 系統** を使い分けます。新規ファイル追加時はこの規則に従ってください。
+
+### 規則表
+
+| 階層                                       | ルール                      | 例                                                               |
+| ------------------------------------------ | --------------------------- | ---------------------------------------------------------------- |
+| **ルート直下 / 番号付きフォルダ直下の MD** | `UPPER_SNAKE_CASE.md`       | `MASTER.md`, `PROJECT.md`, `DEPLOYMENT.md`, `LESSONS_LEARNED.md` |
+| **サブフォルダ名**                         | `lowercase-with-hyphens/`   | `deployment/`, `organizational-rollout/`, `best-practices/`      |
+| **サブフォルダ内 MD**                      | `lowercase-with-hyphens.md` | `git-workflow.md`, `phased-rollout.md`, `ace-cycle.md`           |
+
+### 適用条件
+
+- **ハイフン (`-`) は使わない**: トップレベル MD はアンダースコア区切りで統一する（例: `REVIEW_AGENT_CREATION_GUIDE.md` であって `REVIEW-AGENT-CREATION-GUIDE.md` ではない）
+- **拡張子**: Markdown は `.md`（`.markdown` は使わない）
+- **数字プレフィックス**: 番号付きフォルダ自体（`00-planning/` 等）には付与するが、サブフォルダ内ファイルには付けない（読み順は親索引の表で示す）
+- **大文字小文字**: トップレベル MD はファイル名全体を大文字、サブフォルダおよびその配下のファイルは全て小文字
+
+### 命名規則を逸脱したい場合
+
+逸脱には常に **トレードオフ** があります。次のいずれかに該当する場合のみ、PR 説明欄で理由を明記して逸脱を許容してください。
+
+- 公式 API/プロダクト名がハイフン区切りで広く認知されている
+- 既存のリンク互換性を維持する必要がある（外部からの参照が多い）
+- 自動生成ファイル（テンプレ展開 / lint 出力）
+
+---
+
+## 🚀 利用フロー
+
+### 1. テンプレートをコピー
+
+```bash
+# 例: 自プロジェクトの docs/ にコア 7 文書をコピー
+cp docs-template/MASTER.md your-project/docs/
+cp -r docs-template/01-context/ your-project/docs/
+cp -r docs-template/02-design/ your-project/docs/
+cp -r docs-template/03-implementation/ your-project/docs/
+cp -r docs-template/04-quality/ your-project/docs/
+cp -r docs-template/05-operations/ your-project/docs/
+cp -r docs-template/06-reference/ your-project/docs/
+```
+
+### 2. プレースホルダを埋める
+
+各テンプレ冒頭の YAML frontmatter（`title`, `version`, `status`, `owner`, `created`, `updated`）と、本文中の `{{プロジェクト名}}` 等を自プロジェクトの値に置換します。
+
+### 3. MCP サーバーで整合性チェック
+
+```bash
+cd mcp && npm run check
+```
+
+詳細は ルート [README.md](../README.md) の「導入方法」を参照。
+
+---
+
+## 🔗 関連
+
+- [MASTER.md](./MASTER.md) - 中央ハブ。AI ルール・ツール統合の SSOT
+- [GETTING_STARTED.md](./GETTING_STARTED.md) - 標準セットアップ手順
+- [05-operations/organizational-rollout/document-splitting.md](./05-operations/organizational-rollout/document-splitting.md) - 文書分割の閾値（500/800/1200 行）
+- [06-reference/DECISION_MATRIX.md](./06-reference/DECISION_MATRIX.md) - 「どの文書に書く？」判断ガイド


### PR DESCRIPTION
Closes #408

## 概要

`docs-template/` 配下のファイル名命名規則について、**MASTER.md の既存ルール（ハイフン要求）と実態（30+ ファイルが UPPER_SNAKE_CASE）の乖離** を解消し、実態を正として規則化。SSOT となる `docs-template/README.md` を新設しました。

## 変更内容

### リネーム（2 ファイル）

- `docs-template/06-reference/COPILOT-AGENTS.md` → `COPILOT_AGENTS.md`
- `docs-template/06-reference/REVIEW-AGENT-CREATION-GUIDE.md` → `REVIEW_AGENT_CREATION_GUIDE.md`

### 参照リンク更新（~10 箇所）

| ファイル | 件数 |
|---|---|
| `docs-template/MASTER.md` | 1 |
| `docs-template/05-operations/deployment/multi-cli-review-orchestration.md` | 2 |
| `docs-template/05-operations/deployment/cursor-cli-reviewer.md` | 1 |
| `docs-template/05-operations/deployment/gemini-cli-reviewer.md` | 1 |
| `docs-template/05-operations/deployment/ai-tools-integration.md` | 1 |
| 新 `COPILOT_AGENTS.md` 内（自参照） | 2 |
| 新 `REVIEW_AGENT_CREATION_GUIDE.md` 内（自参照） | 3 |

### ドキュメント追加・修正

- **新規作成**: `docs-template/README.md` — テンプレ内の SSOT として命名規則・構造・利用フローを記載
- **MASTER.md 構造ガイドに表を追加**: 524 行目以降の「ドキュメント構造ガイド（AIツール向け）」内に「ファイル名命名規則」セクションを新設
- **MASTER.md 既存ルール修正**: 241-271 行（コード生成ルール → 命名規則 → ドキュメントファイル）の「アンダースコア区切り禁止（ハイフンを使用）」を「メインドキュメントでのハイフン区切り禁止（UPPER_SNAKE_CASE を使用）」に修正

## 検証

- `cd mcp && npm run check` → `Indexed files=121 sections=1484 specs=2 errors=0`
- `npm run quality:local` → 必須ファイル 7/7 ✅ / 品質警告 0 件 ✅ / Frontmatter 0 件 ✅ / 全体スコア 100%
- `prettier --check` → All matched files use Prettier code style
- `markdownlint-cli2` → 0 error（123 file(s)）
- `grep -rn "COPILOT-AGENTS\|REVIEW-AGENT-CREATION-GUIDE"` → 0 件

## なぜ「実態を正」としたか

- 主流ルール `UPPER_SNAKE_CASE.md` は **34/36 ファイル** で採用済み（`MASTER.md`, `LESSONS_LEARNED.md`, `BEST_PRACTICES.md`, `DEVELOPMENT_PREPARATION.md` 等）
- 一方、MASTER.md の既存ルール（ハイフン要求）に従うとこれら 30+ ファイル全てを `LESSONS-LEARNED.md` 等にリネームする大規模変更が必要
- 実態を正とする方が **撤退コストが低く**、テンプレ利用者の混乱も少ない

## 影響範囲

- ドキュメント変更のみ。ソースコード・MCP サーバー実装への影響なし
- 既存テンプレ展開先（自プロジェクトに `docs-template/` をコピー済みのプロジェクト）には影響しない（このリポジトリ内の整理のみ）