### PR TITLE
docs: #421 ace-cycle.md 分析観点に「判断ログ」を追加（ACE-034 follow-up）

### DIFF
--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -54,6 +54,7 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 4. **パフォーマンス**: 最適化のヒント
 5. **アーキテクチャ**: 構造上の決定事項
 6. **プロセス**: ワークフロー・ツール活用の改善点
+7. **判断ログ**: 捨てた選択肢・spec から逸脱した点・spec にない判断（PR description の implementation-notes 転記より、[ACE-034](../../08-knowledge/PLAYBOOK.md)）
 
 ## 出力形式
 各知見について以下を出力してください:
@@ -300,6 +301,12 @@ git commit -m "knowledge: ACE-006,ACE-007 [performance,testing] Prisma N+1防止
 ---
 
 ## Changelog
+
+### [1.1.0] - 2026-05-20
+
+#### 追加
+
+- Phase 1 Generate AI プロンプトテンプレートに分析観点 7「判断ログ」を追加（Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)）。PR description に転記された implementation-notes（[ACE-034](../../08-knowledge/PLAYBOOK.md)）から「捨てた選択肢 / spec 乖離 / spec にない判断」を明示的に拾わせる
 
 ### [1.0.0] - YYYY-MM-DD
 

--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -29,13 +29,13 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 
 ### 対象データ
 
-| データソース     | 取得方法                                              | 主な知見                                                                                                                 |
-| ---------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| PR diff          | `gh pr diff ${PR_NUMBER}`                             | コード変更のパターン、設計判断                                                                                           |
-| PR description   | `gh pr view ${PR_NUMBER} --json body`                 | 判断理由 / 捨てた選択肢 / spec 乖離（implementation-notes 転記済み、[PLAYBOOK ACE-034](../../08-knowledge/PLAYBOOK.md)） |
-| Issue 内容       | `gh issue view ${ISSUE_NUM}`                          | 元々の課題、要件                                                                                                         |
-| レビューコメント | `gh api repos/OWNER/REPO/pulls/${PR_NUMBER}/comments` | 指摘事項、改善点                                                                                                         |
-| CI/CD ログ       | GitHub Actions の結果                                 | ビルド・テストの教訓                                                                                                     |
+| データソース     | 取得方法                                              | 主な知見                                                                                                                                  |
+| ---------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| PR diff          | `gh pr diff ${PR_NUMBER}`                             | コード変更のパターン、設計判断                                                                                                            |
+| PR description   | `gh pr view ${PR_NUMBER} --json body`                 | spec にない判断 / spec から変更した点 / 捨てた選択肢（implementation-notes 転記済み、[PLAYBOOK ACE-034](../../08-knowledge/PLAYBOOK.md)） |
+| Issue 内容       | `gh issue view ${ISSUE_NUM}`                          | 元々の課題、要件                                                                                                                          |
+| レビューコメント | `gh api repos/OWNER/REPO/pulls/${PR_NUMBER}/comments` | 指摘事項、改善点                                                                                                                          |
+| CI/CD ログ       | GitHub Actions の結果                                 | ビルド・テストの教訓                                                                                                                      |
 
 ### AIプロンプトテンプレート
 
@@ -54,7 +54,7 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 4. **パフォーマンス**: 最適化のヒント
 5. **アーキテクチャ**: 構造上の決定事項
 6. **プロセス**: ワークフロー・ツール活用の改善点
-7. **判断ログ**: 捨てた選択肢・spec から逸脱した点・spec にない判断（PR description の implementation-notes 転記より、[ACE-034](../../08-knowledge/PLAYBOOK.md)）
+7. **判断ログ**: spec にない判断 / spec から変更した点 / 捨てた選択肢（#1「採用した判断」を補完するレイヤ。データソースは上記表「PR description」行、[ACE-034](../../08-knowledge/PLAYBOOK.md)。カテゴリは `process` または `architecture` を推奨。試行中: [Issue #421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、5 PR で評価）
 
 ## 出力形式
 各知見について以下を出力してください:
@@ -306,7 +306,7 @@ git commit -m "knowledge: ACE-006,ACE-007 [performance,testing] Prisma N+1防止
 
 #### 追加
 
-- Phase 1 Generate AI プロンプトテンプレートに分析観点 7「判断ログ」を追加（Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)）。PR description に転記された implementation-notes（[ACE-034](../../08-knowledge/PLAYBOOK.md)）から「捨てた選択肢 / spec 乖離 / spec にない判断」を明示的に拾わせる
+- Phase 1 分析観点に「7. 判断ログ」を追加（試行中、5 PR で評価）。詳細は §Phase 1 観点 7（Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、[ACE-034](../../08-knowledge/PLAYBOOK.md) 連動）
 
 ### [1.0.0] - YYYY-MM-DD
 


### PR DESCRIPTION
Closes #421

## Summary

ACE Phase 1 Generate の AI プロンプトテンプレート (`docs-template/05-operations/deployment/ace-cycle.md` L50-57) の「分析観点」に **7 番目「判断ログ」** を追加した。

PR description に転記された `implementation-notes.md`（[ACE-034](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md)）から「捨てた選択肢 / spec から逸脱した点 / spec にない判断」を明示的に拾わせる文言を追加することで、ACE-034 で増やした raw material が Phase 1 Generate で構造的に活用されるようにする。

## なぜ今やるか（受入基準との関係）

Issue #421 の受入基準は「ACE-034 を 5 PR 以上で運用 → 実例を集めてから判断」だが、以下の理由で「先に観点を追加し、運用してみて効果がなければロールバック」方針を採用:

- ACE-034 自体が今走り始めた直後のため、新観点なしで運用するとプロンプト側が implementation-notes 由来の情報を構造的に無視し続ける
- 観点追加は 1 行差分でロールバックコストが極めて低い
- 5 PR 待ち時に「実は AI が拾えていなかった」と判明するより、最初から観点を入れて運用しながら評価する方がフィードバックループが速い

## 変更内容

### 分析観点 (L50-57)

**追加**: 7 番目の観点

```
7. **判断ログ**: 捨てた選択肢・spec から逸脱した点・spec にない判断
   （PR description の implementation-notes 転記より、ACE-034）
```

**判断**:
- 既存 #1「コーディングパターン: 採用した設計判断とその理由」は **採用した** 判断のみを対象 → **採用しなかった / spec から逸脱した** 軸は別立てで分離
- ラベル「判断ログ」は短く既存 6 観点（コーディングパターン、テスト戦略 等）と並ぶ長さ
- ACE-034 と PR description という参照経路を明示し、AI が raw material を取りに行ける動線を作る

### Changelog (L300-308)

`### [1.1.0] - 2026-05-20` を追加（`### [1.0.0] - YYYY-MM-DD` プレースホルダーの上）。

## 関連

- Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)
- PR [#420](https://github.com/feel-flow/ai-spec-driven-development/pull/420)（ACE-034 導入元）
- [PLAYBOOK ACE-034](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md)

## Test plan

- [x] `npm run quality:local` 通過（必須ファイル 7/7 ✅、品質警告 0件、Prettier ✅、markdownlint ✅）
- [ ] Toolkit セルフレビュー (`/pr-review-toolkit:review-pr`)
- [ ] Copilot review (`request_copilot_review` MCP)
- [ ] 次回 ACE サイクル（本 PR マージ後の `/ace-curate`）で観点 7 が機能するか確認

## ロールバック条件

- 次の 5 PR 程度の ACE 運用で「観点 7 を入れても判断ログが拾えない / ノイズが増えた」と判断された場合、L57 と Changelog 1.1.0 を 1 commit で revert する