### PR TITLE
chore: #426 .codex/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 
 # Brainstorming visual companion (ephemeral mockups)
 .superpowers/
+
+# Codex CLI
+.codex/


### PR DESCRIPTION
Closes #426

## Summary

Codex CLI が repo root に生成する `.codex/config.toml` は個人のローカルツール設定（`.claude/settings.local.json` と同型）。git 管理対象ではないため `.gitignore` に追加する。

## 変更内容

`.gitignore` に 3 行追加（既存の `.superpowers/` の下）:

\`\`\`gitignore
# Codex CLI
.codex/
\`\`\`

## レビュー方針

trivial な .gitignore 1 ファイル / 3 行追加のため、Draft 不要・Toolkit / Copilot 自己レビュースキップで直接 ready。マージ後 PR #423 の cleanup を続行する都合上、最短経路で進める。

## Test plan

- [x] `git status` で `.codex/` が untracked として消えることをローカル確認