### PR TITLE
docs: #425 PLAYBOOK ACE エントリに explicit anchor を付与しリンク参照を統一

### DIFF
--- a/.claude/commands/ace-curate.md
+++ b/.claude/commands/ace-curate.md
@@ -79,6 +79,8 @@ PLAYBOOK.md の既存エントリから最新のIDを確認し、次の連番を
 エントリ一覧セクションの末尾（`## Changelog` の直前）に新エントリを追記:
 
 ```markdown
+<a id="ace-xxx"></a>
+
 ### ACE-XXX: [タイトル]
 
 | フィールド | 値           |
@@ -96,6 +98,8 @@ PLAYBOOK.md の既存エントリから最新のIDを確認し、次の連番を
 
 **Action**: [推奨アクション]
 ```
+
+**anchor 規則**: 見出し直前に `<a id="ace-NNN"></a>` を 1 行付与（`NNN` は小文字 + ハイフン + 3 桁ゼロパディング、例: `ace-042`）。他ドキュメントから `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式で直接ジャンプ可能にする（PLAYBOOK.md 1000 行超対応、Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425)）。
 
 #### 4-c. Frontmatter の更新
 

--- a/.claude/commands/ace-curate.md
+++ b/.claude/commands/ace-curate.md
@@ -99,7 +99,7 @@ PLAYBOOK.md の既存エントリから最新のIDを確認し、次の連番を
 **Action**: [推奨アクション]
 ```
 
-**anchor 規則**: 見出し直前に `<a id="ace-NNN"></a>` を 1 行付与（`NNN` は小文字 + ハイフン + 3 桁ゼロパディング、例: `ace-042`）。他ドキュメントから `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式で直接ジャンプ可能にする（PLAYBOOK.md 1000 行超対応、Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425)）。
+**anchor 命名規則**: 見出し直前に `<a id="ace-NNN"></a>` を 1 行付与（小文字 + ハイフン + 3 桁ゼロパディング）。詳細・根拠は SSOT である [PLAYBOOK.md 記述ガイドライン](../../docs-template/08-knowledge/PLAYBOOK.md#記述ガイドライン) を参照。
 
 #### 4-c. Frontmatter の更新
 

--- a/.claude/commands/ace-curate.md
+++ b/.claude/commands/ace-curate.md
@@ -79,7 +79,7 @@ PLAYBOOK.md の既存エントリから最新のIDを確認し、次の連番を
 エントリ一覧セクションの末尾（`## Changelog` の直前）に新エントリを追記:
 
 ```markdown
-<a id="ace-xxx"></a>
+<a id="ace-XXX"></a>
 
 ### ACE-XXX: [タイトル]
 

--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -166,7 +166,7 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 **Action**: [推奨アクション]
 ```
 
-**anchor 命名規則**: 各エントリの見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-006`, `ace-034`）。他ドキュメントから `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式で特定エントリに直接ジャンプ可能にするため。PLAYBOOK.md は 1000 行超のため、ファイルレベル参照ではジャンプできない（Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425) の経緯）。
+**anchor 命名規則**: 見出し直前に `<a id="ace-NNN"></a>` を 1 行付与（小文字 + ハイフン + 3 桁ゼロパディング）。詳細・根拠は SSOT である [PLAYBOOK.md 記述ガイドライン](../../08-knowledge/PLAYBOOK.md#記述ガイドライン) を参照。
 
 #### 3. Frontmatter の更新
 

--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -17,7 +17,7 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 
 **チーム開発（推奨）**: マージ後 cleanup を済ませた develop から `chore/ace-from-pr-<PR番号>` ブランチを切り、PLAYBOOK.md 追記を小さい chore PR として PR レビュー → squash merge する。複数人が並行で ACE を回す環境では PLAYBOOK.md の append-only 順序競合を防げる。
 
-> **ACE-012 の例外**: 「個人開発（簡易）」パターンの直接 develop push は、通常の `Never commit directly to develop` 禁則（[PLAYBOOK.md ACE-012](../../08-knowledge/PLAYBOOK.md)）の**明示的な例外**として位置付ける。詳細な根拠は [git-workflow.md ステップ10 ACE](./git-workflow.md) 参照。
+> **ACE-012 の例外**: 「個人開発（簡易）」パターンの直接 develop push は、通常の `Never commit directly to develop` 禁則（[ACE-012](../../08-knowledge/PLAYBOOK.md#ace-012)）の**明示的な例外**として位置付ける。詳細な根拠は [git-workflow.md ステップ10 ACE](./git-workflow.md) 参照。
 
 **autonomous（任意）**: subagent と専用 worktree で ACE キャプチャを非同期化するパターン。導入は [ace-autonomous.md](./ace-autonomous.md) と `docs-template/scripts/ace/` のテンプレートを参照（Issue [#367](https://github.com/feel-flow/ai-spec-driven-development/issues/367)）。
 
@@ -29,13 +29,13 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 
 ### 対象データ
 
-| データソース     | 取得方法                                              | 主な知見                                                                                                                                  |
-| ---------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| PR diff          | `gh pr diff ${PR_NUMBER}`                             | コード変更のパターン、設計判断                                                                                                            |
-| PR description   | `gh pr view ${PR_NUMBER} --json body`                 | spec にない判断 / spec から変更した点 / 捨てた選択肢（implementation-notes 転記済み、[PLAYBOOK ACE-034](../../08-knowledge/PLAYBOOK.md)） |
-| Issue 内容       | `gh issue view ${ISSUE_NUM}`                          | 元々の課題、要件                                                                                                                          |
-| レビューコメント | `gh api repos/OWNER/REPO/pulls/${PR_NUMBER}/comments` | 指摘事項、改善点                                                                                                                          |
-| CI/CD ログ       | GitHub Actions の結果                                 | ビルド・テストの教訓                                                                                                                      |
+| データソース     | 取得方法                                              | 主な知見                                                                                                                                 |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| PR diff          | `gh pr diff ${PR_NUMBER}`                             | コード変更のパターン、設計判断                                                                                                           |
+| PR description   | `gh pr view ${PR_NUMBER} --json body`                 | spec にない判断 / spec から変更した点 / 捨てた選択肢（implementation-notes 転記済み、[ACE-034](../../08-knowledge/PLAYBOOK.md#ace-034)） |
+| Issue 内容       | `gh issue view ${ISSUE_NUM}`                          | 元々の課題、要件                                                                                                                         |
+| レビューコメント | `gh api repos/OWNER/REPO/pulls/${PR_NUMBER}/comments` | 指摘事項、改善点                                                                                                                         |
+| CI/CD ログ       | GitHub Actions の結果                                 | ビルド・テストの教訓                                                                                                                     |
 
 ### AIプロンプトテンプレート
 
@@ -54,7 +54,7 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 4. **パフォーマンス**: 最適化のヒント
 5. **アーキテクチャ**: 構造上の決定事項
 6. **プロセス**: ワークフロー・ツール活用の改善点
-7. **判断ログ**: spec にない判断 / spec から変更した点 / 捨てた選択肢（#1「採用した判断」を補完するレイヤ。データソースは上記表「PR description」行、[ACE-034](../../08-knowledge/PLAYBOOK.md)。カテゴリは `process` または `architecture` を推奨。試行中: [Issue #421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、5 PR で評価）
+7. **判断ログ**: spec にない判断 / spec から変更した点 / 捨てた選択肢（#1「採用した判断」を補完するレイヤ。データソースは上記表「PR description」行、[ACE-034](../../08-knowledge/PLAYBOOK.md#ace-034)。カテゴリは `process` または `architecture` を推奨。試行中: [Issue #421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、5 PR で評価）
 
 ## 出力形式
 各知見について以下を出力してください:
@@ -146,6 +146,8 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 エントリ一覧セクションの末尾に追記：
 
 ```markdown
+<a id="ace-006"></a>
+
 ### ACE-006: [タイトル]
 
 | フィールド | 値               |
@@ -163,6 +165,8 @@ ACE (Agentic Context Engineering) サイクルは、マージ後・cleanup 後�
 
 **Action**: [推奨アクション]
 ```
+
+**anchor 命名規則**: 各エントリの見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-006`, `ace-034`）。他ドキュメントから `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式で特定エントリに直接ジャンプ可能にするため。PLAYBOOK.md は 1000 行超のため、ファイルレベル参照ではジャンプできない（Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425) の経緯）。
 
 #### 3. Frontmatter の更新
 
@@ -306,7 +310,7 @@ git commit -m "knowledge: ACE-006,ACE-007 [performance,testing] Prisma N+1防止
 
 #### 追加
 
-- Phase 1 分析観点に「7. 判断ログ」を追加（試行中、5 PR で評価）。詳細は §Phase 1 観点 7（Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、[ACE-034](../../08-knowledge/PLAYBOOK.md) 連動）
+- Phase 1 分析観点に「7. 判断ログ」を追加（試行中、5 PR で評価）。詳細は §Phase 1 観点 7（Issue [#421](https://github.com/feel-flow/ai-spec-driven-development/issues/421)、[ACE-034](../../08-knowledge/PLAYBOOK.md#ace-034) 連動）
 
 ### [1.0.0] - YYYY-MM-DD
 

--- a/docs-template/05-operations/deployment/git-workflow.md
+++ b/docs-template/05-operations/deployment/git-workflow.md
@@ -122,7 +122,7 @@ git checkout -b "feature/${ISSUE_NUM}-user-auth"
 
 #### 作業中の判断ログ: `implementation-notes.md` を並走させる
 
-実装着手と同時に **作業ブランチ直下** に `implementation-notes.md` を作成し、コミットと一緒に追記する。コミット diff には残らない「なぜこの選択をしたか / spec から変えた点 / 捨てた選択肢」を保持することで、ステップ5（Self-Review）の精度とステップ10（ACE Generate）の入力品質が上がる。詳細根拠は [PLAYBOOK ACE-034](../../08-knowledge/PLAYBOOK.md)。
+実装着手と同時に **作業ブランチ直下** に `implementation-notes.md` を作成し、コミットと一緒に追記する。コミット diff には残らない「なぜこの選択をしたか / spec から変えた点 / 捨てた選択肢」を保持することで、ステップ5（Self-Review）の精度とステップ10（ACE Generate）の入力品質が上がる。詳細根拠は [ACE-034](../../08-knowledge/PLAYBOOK.md#ace-034)。
 
 最小ひな形（コピペして使う）:
 
@@ -148,7 +148,7 @@ git checkout -b "feature/${ISSUE_NUM}-user-auth"
 
 **運用ルール**:
 
-- **書くタイミングは「気付いた瞬間」**: 後で書こうとすると確実に忘れる（[ACE-032](../../08-knowledge/PLAYBOOK.md) の発見経緯と同じ構造）
+- **書くタイミングは「気付いた瞬間」**: 後で書こうとすると確実に忘れる（[ACE-032](../../08-knowledge/PLAYBOOK.md#ace-032) の発見経緯と同じ構造）
 - **粒度は 1〜3 行**: 「なぜ A ではなく B を選んだか」を短文で残す
 - **スコープ外発見は本ファイルではなく Issue 化**: implementation-notes は「現 PR の判断ログ」、Issue は「別タスクへの分岐」と役割を分ける（[ワークフロー運用原則 原則2](./workflow-principles.md)）
 - **PR 作成時に PR description に転記**: ステップ6 でレビュアーが「なぜ」を読みやすくなる
@@ -807,7 +807,7 @@ GitHub Discussions への記録に加え、ACE Playbook への構造化記録を
 
 **チーム開発（推奨）**: マージ後 cleanup を済ませた develop から `chore/ace-from-pr-<PR番号>` ブランチを切り、PLAYBOOK.md 追記を小さい chore PR として PR レビュー → squash merge する。複数人が並行で ACE を回す環境では PLAYBOOK.md の append-only 順序競合を防げる。
 
-> **ACE-012 の例外として明示**: 通常 develop への直接 commit は禁止（[PLAYBOOK.md ACE-012](../../08-knowledge/PLAYBOOK.md)）だが、**「個人開発（簡易）」パターンに限り PLAYBOOK.md 単独追記の直接 push を例外として許容する**。理由: (1) PLAYBOOK.md は append-only で構造化されており他コミッタの追記と競合しにくい、(2) 1 サイクル分の知見追加は履歴上独立 commit として読める、(3) `knowledge:` プレフィックスで他のコミットと識別可能。コミッタ 3 人以上のリポジトリでは「チーム開発（推奨）」パターンを必須とし、この例外は適用しない。
+> **ACE-012 の例外として明示**: 通常 develop への直接 commit は禁止（[ACE-012](../../08-knowledge/PLAYBOOK.md#ace-012)）だが、**「個人開発（簡易）」パターンに限り PLAYBOOK.md 単独追記の直接 push を例外として許容する**。理由: (1) PLAYBOOK.md は append-only で構造化されており他コミッタの追記と競合しにくい、(2) 1 サイクル分の知見追加は履歴上独立 commit として読める、(3) `knowledge:` プレフィックスで他のコミットと識別可能。コミッタ 3 人以上のリポジトリでは「チーム開発（推奨）」パターンを必須とし、この例外は適用しない。
 
 ## タスク管理（Task Tracking）
 

--- a/docs-template/05-operations/deployment/knowledge-management.md
+++ b/docs-template/05-operations/deployment/knowledge-management.md
@@ -65,6 +65,12 @@ GitHub Discussions は **人間が読むためのナラティブ（物語的記�
 | 形式     | 構造化テーブル + 短文      | 自由記述               |
 | 更新頻度 | 毎回のマージ後・cleanup 後 | 重要な知見のみ         |
 
+### Playbook エントリの anchor 規則
+
+- 新規エントリには見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する（小文字 + ハイフン + 3 桁ゼロパディング）。
+- 他ドキュメントからの参照は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する（PLAYBOOK.md は 1000 行超のためファイルレベル参照ではジャンプできない）。
+- 詳細手順は [ace-cycle.md Phase 3](./ace-cycle.md) を参照。
+
 詳細: [ace-cycle.md](./ace-cycle.md)
 
 マージ後のキャプチャを **人手から切り離す** 場合は、[ace-autonomous.md](./ace-autonomous.md) の autonomous パターン（feature flag・garden wall・shadow 運用）を参照してください。

--- a/docs-template/05-operations/deployment/knowledge-management.md
+++ b/docs-template/05-operations/deployment/knowledge-management.md
@@ -67,9 +67,8 @@ GitHub Discussions は **人間が読むためのナラティブ（物語的記�
 
 ### Playbook エントリの anchor 規則
 
-- 新規エントリには見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する（小文字 + ハイフン + 3 桁ゼロパディング）。
-- 他ドキュメントからの参照は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する（PLAYBOOK.md は 1000 行超のためファイルレベル参照ではジャンプできない）。
-- 詳細手順は [ace-cycle.md Phase 3](./ace-cycle.md) を参照。
+- 命名規則の SSOT は [PLAYBOOK.md 記述ガイドライン](../../08-knowledge/PLAYBOOK.md#記述ガイドライン) を参照（フォーマット・参照リンク形式の正典）。
+- 実装手順は [ace-cycle.md Phase 3](./ace-cycle.md) を参照。
 
 詳細: [ace-cycle.md](./ace-cycle.md)
 

--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -94,8 +94,8 @@ GitHub Discussions が「人間が読むためのナラティブ（物語的記�
 
 ### 記述ガイドライン
 
-- **anchor**: 各エントリは見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-001`, `ace-034`）。これにより他ドキュメントから `[ACE-034](path/to/PLAYBOOK.md#ace-034)` 形式で**特定エントリに直接ジャンプ可能**になる（PLAYBOOK.md は 1000 行を超えるためファイルレベル参照ではジャンプできない）。
-- **参照リンク形式**: 他ドキュメントから ACE エントリを参照する場合は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する。`[PLAYBOOK ACE-NNN]` / `[PLAYBOOK.md ACE-NNN]` 等の異なる label は使わない（[ACE-024](#ace-024) 用語統一の系）。
+- **anchor**: 各エントリは見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-001`, `ace-034`）。ファイルレベル参照（`PLAYBOOK.md` 単体）は常にファイル先頭に着地するため、anchor がなければ個別エントリへの誘導が成立しない。anchor 付与により他ドキュメントから `[ACE-034](path/to/PLAYBOOK.md#ace-034)` 形式で**特定エントリに直接ジャンプ可能**になる。
+- **参照リンク形式**: 他ドキュメントから ACE エントリを参照する場合は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する。`[PLAYBOOK ACE-NNN]` / `[PLAYBOOK.md ACE-NNN]` 等の異なる label は使わない（[ACE-040](#ace-040) 語彙統一 / [ACE-024](#ace-024) 用語衝突防止 の系。Origin: Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425)）。
 - **Insight**: 「何を学んだか」を簡潔に。1-2文。
 - **Context**: 「どんな状況で発見したか」を記述。再現条件が明確であるほど価値が高い。
 - **Action**: 「次回何をすべきか」を具体的に。コード例があると AIツールが直接適用しやすい。
@@ -155,9 +155,9 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 <!-- ここから下にエントリを追記してください。最新のエントリが末尾になるように追記します。 -->
 <!-- 追記例:
-<a id="ace-001"></a>
+<a id="ace-xxx"></a>
 
-### ACE-001: N+1クエリの発生パターンと防止策
+### ACE-XXX: N+1クエリの発生パターンと防止策
 
 | フィールド | 値 |
 |-----------|---|
@@ -1262,6 +1262,14 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 ---
 
 ## Changelog
+
+### [1.19.0] - 2026-05-20
+
+#### 追加
+
+- ACE-001〜041 の各エントリ直前に explicit anchor (`<a id="ace-NNN"></a>`) を 41 件付与（Issue #425）
+- エントリテンプレート / 記述ガイドラインに anchor 命名規則を追加（小文字 + ハイフン + 3 桁ゼロパディング）
+- 他ドキュメントからの ACE 参照を `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一（旧 3 形式を撤去）
 
 ### [1.18.0] - 2026-05-20
 

--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -1,6 +1,6 @@
 ---
 title: "PLAYBOOK"
-version: "1.18.0"
+version: "1.19.0"
 status: "approved"
 created: "2026-03-10"
 updated: "2026-05-20"
@@ -72,6 +72,8 @@ GitHub Discussions が「人間が読むためのナラティブ（物語的記�
 新しいエントリを追記する際は、以下のテンプレートを使用してください：
 
 ```markdown
+<a id="ace-xxx"></a>
+
 ### ACE-XXX: [タイトル（簡潔で検索しやすい表現）]
 
 | フィールド | 値                                                                                    |
@@ -92,6 +94,8 @@ GitHub Discussions が「人間が読むためのナラティブ（物語的記�
 
 ### 記述ガイドライン
 
+- **anchor**: 各エントリは見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-001`, `ace-034`）。これにより他ドキュメントから `[ACE-034](path/to/PLAYBOOK.md#ace-034)` 形式で**特定エントリに直接ジャンプ可能**になる（PLAYBOOK.md は 1000 行を超えるためファイルレベル参照ではジャンプできない）。
+- **参照リンク形式**: 他ドキュメントから ACE エントリを参照する場合は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する。`[PLAYBOOK ACE-NNN]` / `[PLAYBOOK.md ACE-NNN]` 等の異なる label は使わない（[ACE-024](#ace-024) 用語統一の系）。
 - **Insight**: 「何を学んだか」を簡潔に。1-2文。
 - **Context**: 「どんな状況で発見したか」を記述。再現条件が明確であるほど価値が高い。
 - **Action**: 「次回何をすべきか」を具体的に。コード例があると AIツールが直接適用しやすい。
@@ -151,6 +155,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 <!-- ここから下にエントリを追記してください。最新のエントリが末尾になるように追記します。 -->
 <!-- 追記例:
+<a id="ace-001"></a>
+
 ### ACE-001: N+1クエリの発生パターンと防止策
 
 | フィールド | 値 |
@@ -168,6 +174,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 **Action**: 一覧取得時は `include` オプションで関連を一括取得する。`findMany({ include: { organization: true } })`
 -->
+
+<a id="ace-001"></a>
 
 ### ACE-001: クロスモデルレビューは単一AIモデルでは検出できない問題を発見する
 
@@ -188,6 +196,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-002"></a>
+
 ### ACE-002: CLIフラグは実機の --help 出力と照合が必須
 
 | フィールド | 値                   |
@@ -206,6 +216,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 **Action**: CLI ツールのフラグを記述する際は、(1) `command --help` で実機確認、(2) 公式リポジトリの README/docs と照合、(3) 可能なら `--dry-run` 等で動作確認、の3ステップを必ず実施する。
 
 ---
+
+<a id="ace-003"></a>
 
 ### ACE-003: bash スクリプトは macOS デフォルト環境（bash 3.2）でテストする
 
@@ -226,6 +238,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-004"></a>
+
 ### ACE-004: ドキュメントの動作説明は実装メカニズムと一致させる
 
 | フィールド | 値         |
@@ -244,6 +258,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 **Action**: ドキュメントに動作説明を書く際は、(1) 実装コード/設定ファイルで実際の動作を確認、(2) 記載するコマンドは実在を検証（`package.json`のscripts、`--help`出力等）、(3) 「自動」「手動」等の表現は実装メカニズムに基づいて正確に選択する。
 
 ---
+
+<a id="ace-005"></a>
 
 ### ACE-005: 索引と実体を分離する委譲パターンでAIコンテキスト消費を抑える
 
@@ -264,6 +280,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-006"></a>
+
 ### ACE-006: サンプル付きテンプレファイルには⚠️SAMPLEバナーと固有化手順を必ず併設する
 
 | フィールド | 値                   |
@@ -282,6 +300,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 **Action**: docs-template に具体例（コードパス、ドメイン名、実装名）を含む新規テンプレファイルを追加する際は: (1) ファイル冒頭に `> ⚠️ **SAMPLE — テンプレートです**` 引用ブロックと書き換え案内を配置、(2) 末尾に「プロジェクト固有化の手順」セクション（番号付き手順 + frontmatter の `created/updated/owner` 置換まで含める）を配置、(3) 該当しない分岐・セクションは「**該当セクションごと削除してよい**」と明記、(4) 該当する失敗モード（採用後にサンプルのまま残る等）を仕様書側にリストアップしておく。
 
 ---
+
+<a id="ace-007"></a>
 
 ### ACE-007: Claude Code skill 内のツール参照は名称・subagent_type を実機 / system prompt で照合する
 
@@ -302,6 +322,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-008"></a>
+
 ### ACE-008: クロスリポジトリ操作する skill は全 gh コマンドに `--repo` 必須・mention は `@<assignee>` を使う
 
 | フィールド | 値                   |
@@ -321,6 +343,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-009"></a>
+
 ### ACE-009: 長時間 Orchestrator の失敗の真因は upstream Issue spec 曖昧さ — 探索型 refine が必要
 
 | フィールド | 値                   |
@@ -339,6 +363,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 **Action**: 「AI agent が信頼できない / 完遂率が低い」と感じたら、(1) agent 自体の改善より先に、与えている入力データ (Issue / spec / プロンプト) の品質を疑う、(2) upstream に「入力を磨く skill」を置けないか検討する、(3) ブレストで「真因が一段下のレイヤーにある」可能性を必ず一度は検証する、(4) MVP は upstream の単一 skill に絞り、Orchestrator ループ等は動作確認後に後付けする路線が安全（空回りを高速化するリスクを避ける）。
 
 ---
+
+<a id="ace-010"></a>
 
 ### ACE-010: Issue クローズ前は commit log でなく現在のファイル実体を grep 照合する — silent regression を検出する
 
@@ -363,6 +389,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 4. **AI エージェントが「クローズ判断」のような shared state 操作を行う前に advisor / 別 agent に検証させる** — 大規模リポジトリで commit メッセージだけで判断するのはハイリスク。
 
 ---
+
+<a id="ace-011"></a>
 
 ### ACE-011: Prettier × markdownlint MD060 衝突は当該テーブルだけに `<!-- prettier-ignore -->` を付与する局所抑制で解く
 
@@ -389,6 +417,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-012"></a>
+
 ### ACE-012: PR マージ・push 前は必ず `git status` でブランチを確認する（develop 直 push 事故防止）
 
 | フィールド | 値                             |
@@ -414,6 +444,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-013"></a>
+
 ### ACE-013: 並列 reviewer の指摘は古い snapshot 由来の誤検知を含む — 実態 grep で双方向検証する
 
 | フィールド | 値                             |
@@ -438,6 +470,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 5. **逆方向の罠も警戒**: 「Toolkit が指摘していないから OK」と思い込まず、自分の追記内容（特にテンプレート実態に関する主張）は `ls` / `cat` で実物を確認してから書く。**書きながら一度実物を見る**を習慣にする。
 
 ---
+
+<a id="ace-014"></a>
 
 ### ACE-014: 索引文書は SSOT を子に集約し、自身は誘導と 1 行サマリのみ — 数値の重複は持たない
 
@@ -465,6 +499,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-015"></a>
+
 ### ACE-015: 表を導入したら散文の主張を表に対して再読する — 「N 段階」「太字の領域」型の自己矛盾は人手レビューで見落とされる
 
 | フィールド | 値                    |
@@ -489,6 +525,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 5. **数値境界は排他的整数で書く**: 「200 行以下 / 200〜400 / 400 超」のような両端重複ではなく「200 行以下 / 201〜400 / 401 行以上」のように境界が排他になる書き方を使う（boundary inclusivity の曖昧さも自己矛盾の一種）。
 
 ---
+
+<a id="ace-016"></a>
 
 ### ACE-016: Markdown の anchor link は label と URL の両方にフラグメントを書く — `\[text#anchor\]\(url\)` 形式は無効
 
@@ -516,6 +554,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-017"></a>
+
 ### ACE-017: 並列 review agent は worktree を巻き戻す副作用を持ち得る — `git status` 監視と `git restore --source=HEAD` で復旧する
 
 | フィールド | 値                   |
@@ -540,6 +580,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 5. **`git reset --hard` を含む destructive 操作の禁止周知**: agent prompt に「**`git reset --hard` / `git restore --source=<base>` / `git checkout <base> -- .` は実行禁止。read-only 操作（`git diff`, `git show`, `git log`）に限定する**」と明記する。レビュー目的ならどの操作も destructive 不要。
 
 ---
+
+<a id="ace-018"></a>
 
 ### ACE-018: 横断的な番号・順序変更は着手前に grep で全 SSOT を列挙する
 
@@ -572,6 +614,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-019"></a>
+
 ### ACE-019: 既存ルール違反になる新パターンは「例外」として明示的に名乗らせる
 
 | フィールド | 値                   |
@@ -601,6 +645,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-020"></a>
+
 ### ACE-020: 自動コンテンツ生成ツールは自身のマーカー文字列を本文に含むドキュメントを破壊する
 
 | フィールド | 値                   |
@@ -626,6 +672,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 5. **post-merge / pre-commit など強制実行系に ship する前に dry-run モードを通す**: 自動化に組み込む前に、`--dry-run` で全対象ファイルへの想定変更を出力して目視レビューする。lint フックや husky に直接組み込んだ後はバグの被害が回復しにくい。
 
 ---
+
+<a id="ace-021"></a>
 
 ### ACE-021: テンプレ配布リポでは「リポ自身が使うインフラ」と「テンプレ利用者が受け取る成果物」を物理的に分離する
 
@@ -653,6 +701,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-022"></a>
+
 ### ACE-022: 機能削除時は consumer だけでなく定数・型・ユーティリティも grep して取り残しを防ぐ
 
 | フィールド | 値                   |
@@ -679,6 +729,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-023"></a>
+
 ### ACE-023: ドキュメント中の事実主張（PR/Issue 番号・ハッシュ・数値）は執筆時に 1 次情報で照合する
 
 | フィールド | 値                    |
@@ -702,6 +754,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 3. **数値**: `gh pr view <N> --json additions,deletions,changedFiles` で 1 次情報取得、または `git show --stat <merge-commit>`
 
 ---
+
+<a id="ace-024"></a>
 
 ### ACE-024: SSOT で確立した用語を再利用する前に既存定義との衝突を確認する
 
@@ -729,6 +783,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 ---
 
+<a id="ace-025"></a>
+
 ### ACE-025: スクリプトの「対象範囲」を文書化するときは glob 表現ではなく実装上の対象列挙方式まで踏み込む
 
 | フィールド | 値                    |
@@ -754,6 +810,8 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 5. **glob と固定リストの混在に注意**: 「対象は `docs/**/*.md` だが、一部除外あり」のようなパターンは特に誤解されやすいので除外ルールも明記
 
 ---
+
+<a id="ace-026"></a>
 
 ### ACE-026: 同名関数が複数ファイルに併存する場合は機能対応表で並列説明する
 
@@ -787,6 +845,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-027"></a>
+
 ### ACE-027: 配布対象ファイル内の行番号 hard-coded 参照は採用後に即陳腐化するため heading anchor 化する
 
 | フィールド | 値                    |
@@ -812,6 +872,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 5. **GitHub Markdown の anchor slug ルールを把握**: 日本語見出しは小文字化されず空白は `-` に変換、特殊文字は除去される。`#プロジェクト識別情報` のように見出し文字列そのままで動く
 
 ---
+
+<a id="ace-028"></a>
 
 ### ACE-028: 外部ツールの「現状」仕様を書くときは公式ドキュメントを WebFetch / WebSearch で必ず照合する
 
@@ -839,6 +901,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-029"></a>
+
 ### ACE-029: 外部ツール依存物（shell script の依存コマンド、shebang、インストーラオプション）を文書化するときは実体を読んで列挙する
 
 | フィールド | 値                    |
@@ -864,6 +928,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 5. **未検証の主張は弱める**: 「Windows + Git Bash で `/merge-cleanup` も動く」のような実機検証していない主張は、「⚠️ 大半は動作（未検証）」のように記号と注釈で正直に表現
 
 ---
+
+<a id="ace-030"></a>
 
 ### ACE-030: 対応表で `⚠️` を多用したら判定軸自体が間違っているサイン
 
@@ -891,6 +957,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-031"></a>
+
 ### ACE-031: ドキュメントを書くときは配布境界に基づいて「想定読者」を意識する（採用者向け / コントリビューター向け / リポメンテナ向け）
 
 | フィールド | 値                    |
@@ -916,6 +984,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 5. **採用者向けドキュメントは「採用後にも参照される運用ガイド」「採用前に読む手順書（frontmatter なし）」に分ける**: 後者は `docs-template/README.md:121` で「frontmatter を持たないテンプレ」として明示されている
 
 ---
+
+<a id="ace-032"></a>
 
 ### ACE-032: 機能撤去型の改稿後は、残った value 主張・周辺記述・論理連鎖が全て成立しているか改めて読み直す
 
@@ -943,6 +1013,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-033"></a>
+
 ### ACE-033: 対応表で全行 / 全 cell が uniform になったら、表自体が情報を持っていないサイン
 
 | フィールド | 値                    |
@@ -968,6 +1040,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 5. **撤去 PR で特に発生しやすい**: 機能撤去で表の行・列が減ったら、残った表が uniform になっていないか必ず確認（ACE-032 と連動）
 
 ---
+
+<a id="ace-034"></a>
 
 ### ACE-034: 実装中は implementation-notes.md を作業ブランチに並走させて spec 乖離・トレードオフ・判断理由を捕捉する
 
@@ -1000,6 +1074,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-035"></a>
+
 ### ACE-035: 新規 process パターンを Playbook に追加するときは「ドッグフード + advisor / second opinion」で運用上の構造問題を検出する
 
 | フィールド | 値                |
@@ -1024,6 +1100,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 4. **構造問題が見つかったら pivot 経緯を implementation-notes.md に記録**: pivot 自体が ACE Phase 1 の raw material になる（ACE-034 と組み合わせる）
 
 ---
+
+<a id="ace-036"></a>
 
 ### ACE-036: 外部知見（SNS / ブログ / 社内 wiki）を Playbook に取り込む前に既存 ACE エントリ全件と grep 照合する
 
@@ -1050,6 +1128,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-037"></a>
+
 ### ACE-037: ACE エントリの新規追加は対応する運用手順（workflow / self-review / ace-cycle）への組み込みを同 PR で済ませる
 
 | フィールド | 値                          |
@@ -1074,6 +1154,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 4. **PR レビューで「運用手順との整合性」指摘が出たら本 Insight の発動サイン**: 「組み込み忘れ」ではなく「組み込み計画段階の漏れ」として再発防止を考える（実装後の追記ではなく Issue 段階で判定する）
 
 ---
+
+<a id="ace-038"></a>
 
 ### ACE-038: 「データ収集待ち」を要求する受入基準でも、ロールバック容易な変更は先行実装 + 試行中ステータス明記でフィードバックループを早める
 
@@ -1100,6 +1182,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-039"></a>
+
 ### ACE-039: AI プロンプトテンプレに「分析観点リスト」と「分類カテゴリリスト」が並存する場合、新観点追加時はカテゴリ対応を観点側に明記する
 
 | フィールド | 値                |
@@ -1124,6 +1208,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 
 ---
 
+<a id="ace-040"></a>
+
 ### ACE-040: AI プロンプトテンプレ内で同概念を複数の語で表現すると AI 出力品質が下がる — 一次定義（SSOT）の語彙に統一する
 
 | フィールド | 値                |
@@ -1147,6 +1233,8 @@ Toolkit comment-analyzer が Critical C1/C2 として独立検出、Copilot revi
 3. **レビュー段階で表記揺れが検出されたら、変更箇所だけでなくファイル全体を grep で確認して同 commit で統一する**: 部分修正だとレビュー後に新たな揺れが入る
 
 ---
+
+<a id="ace-041"></a>
 
 ### ACE-041: マージ後 cleanup の未追跡ファイルガードに引っかかったら、独立した chore PR で .gitignore 追加して cleanup を継続する
 

--- a/docs-template/08-knowledge/PLAYBOOK.md
+++ b/docs-template/08-knowledge/PLAYBOOK.md
@@ -72,7 +72,7 @@ GitHub Discussions が「人間が読むためのナラティブ（物語的記�
 新しいエントリを追記する際は、以下のテンプレートを使用してください：
 
 ```markdown
-<a id="ace-xxx"></a>
+<a id="ace-XXX"></a>
 
 ### ACE-XXX: [タイトル（簡潔で検索しやすい表現）]
 
@@ -94,8 +94,8 @@ GitHub Discussions が「人間が読むためのナラティブ（物語的記�
 
 ### 記述ガイドライン
 
-- **anchor**: 各エントリは見出し直前に `<a id="ace-NNN"></a>` を 1 行付与する。`NNN` は小文字 + ハイフン + 3 桁ゼロパディング（例: `ace-001`, `ace-034`）。ファイルレベル参照（`PLAYBOOK.md` 単体）は常にファイル先頭に着地するため、anchor がなければ個別エントリへの誘導が成立しない。anchor 付与により他ドキュメントから `[ACE-034](path/to/PLAYBOOK.md#ace-034)` 形式で**特定エントリに直接ジャンプ可能**になる。
-- **参照リンク形式**: 他ドキュメントから ACE エントリを参照する場合は `[ACE-NNN](path/to/PLAYBOOK.md#ace-nnn)` 形式に統一する。`[PLAYBOOK ACE-NNN]` / `[PLAYBOOK.md ACE-NNN]` 等の異なる label は使わない（[ACE-040](#ace-040) 語彙統一 / [ACE-024](#ace-024) 用語衝突防止 の系。Origin: Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425)）。
+- **anchor**: 各エントリは見出し直前に `<a id="ace-XXX"></a>` を 1 行付与する。`XXX` は **3 桁ゼロパディング数字に置換**（例: `ace-001`, `ace-034`、anchor 部分は常に小文字英数字）。ファイルレベル参照（`PLAYBOOK.md` 単体）は常にファイル先頭に着地するため、anchor がなければ個別エントリへの誘導が成立しない。anchor 付与により他ドキュメントから `[ACE-034](path/to/PLAYBOOK.md#ace-034)` 形式で**特定エントリに直接ジャンプ可能**になる。
+- **参照リンク形式**: 他ドキュメントから ACE エントリを参照する場合は `[ACE-XXX](path/to/PLAYBOOK.md#ace-XXX)` 形式に統一する（`XXX` を 3 桁数字に置換）。`[PLAYBOOK ACE-XXX]` / `[PLAYBOOK.md ACE-XXX]` 等の異なる label は使わない（[ACE-040](#ace-040) 語彙統一 / [ACE-024](#ace-024) 用語衝突防止 の系。Origin: Issue [#425](https://github.com/feel-flow/ai-spec-driven-development/issues/425)）。
 - **Insight**: 「何を学んだか」を簡潔に。1-2文。
 - **Context**: 「どんな状況で発見したか」を記述。再現条件が明確であるほど価値が高い。
 - **Action**: 「次回何をすべきか」を具体的に。コード例があると AIツールが直接適用しやすい。
@@ -155,7 +155,7 @@ Playbook が 800 行を超えた場合、以下のように分割する：
 
 <!-- ここから下にエントリを追記してください。最新のエントリが末尾になるように追記します。 -->
 <!-- 追記例:
-<a id="ace-xxx"></a>
+<a id="ace-XXX"></a>
 
 ### ACE-XXX: N+1クエリの発生パターンと防止策
 

--- a/docs/AI_GIT_WORKFLOW.md
+++ b/docs/AI_GIT_WORKFLOW.md
@@ -157,7 +157,7 @@ git checkout -b "feature/123-user-auth"
 
 #### 作業中の判断ログ: `implementation-notes.md` を並走させる
 
-実装着手と同時に **作業ブランチ直下** に `implementation-notes.md` を作成し、コミットと一緒に追記する。コミット diff には残らない「なぜこの選択をしたか / spec から変えた点 / 捨てた選択肢」を保持することで、ステップ5（Self-Review）の精度とステップ10（ACE Generate）の入力品質が上がる。詳細根拠は [PLAYBOOK ACE-034](../docs-template/08-knowledge/PLAYBOOK.md)。
+実装着手と同時に **作業ブランチ直下** に `implementation-notes.md` を作成し、コミットと一緒に追記する。コミット diff には残らない「なぜこの選択をしたか / spec から変えた点 / 捨てた選択肢」を保持することで、ステップ5（Self-Review）の精度とステップ10（ACE Generate）の入力品質が上がる。詳細根拠は [ACE-034](../docs-template/08-knowledge/PLAYBOOK.md#ace-034)。
 
 最小ひな形（コピペして使う）:
 
@@ -468,7 +468,7 @@ gh discussion create \
 
 > **どちらを選ぶか**: コミッタが 1〜2 人のリポジトリは「個人開発」、3 人以上または ACE 内容のレビューを残したいリポジトリは「チーム開発」を選ぶ。判断基準を README / CLAUDE.md に明記してチーム内で揃える。
 >
-> **ACE-012 の例外として明示**: 通常 develop への直接 commit は禁止（[PLAYBOOK.md ACE-012](../docs-template/08-knowledge/PLAYBOOK.md)）だが、**「個人開発（簡易）」パターンに限り PLAYBOOK.md 単独追記の直接 push を例外として許容する**。理由: (1) PLAYBOOK.md は append-only で構造化されており他コミッタの追記と競合しにくい、(2) 1 サイクル分の知見追加は履歴上独立 commit として読める、(3) `knowledge:` プレフィックスで他のコミットと識別可能。コミッタ 3 人以上のリポジトリでは「チーム開発（推奨）」パターンを必須とし、この例外は適用しない。
+> **ACE-012 の例外として明示**: 通常 develop への直接 commit は禁止（[ACE-012](../docs-template/08-knowledge/PLAYBOOK.md#ace-012)）だが、**「個人開発（簡易）」パターンに限り PLAYBOOK.md 単独追記の直接 push を例外として許容する**。理由: (1) PLAYBOOK.md は append-only で構造化されており他コミッタの追記と競合しにくい、(2) 1 サイクル分の知見追加は履歴上独立 commit として読める、(3) `knowledge:` プレフィックスで他のコミットと識別可能。コミッタ 3 人以上のリポジトリでは「チーム開発（推奨）」パターンを必須とし、この例外は適用しない。
 
 ---
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -33,7 +33,7 @@ changeImpact: high
 ### 関連
 
 - 概念解説: [AI Spec Driven Development](./AI_SPEC_DRIVEN_DEVELOPMENT.md)
-- AI 向け構造化知見: [PLAYBOOK.md](../docs-template/08-knowledge/PLAYBOOK.md) ACE-021
+- AI 向け構造化知見: [ACE-021](../docs-template/08-knowledge/PLAYBOOK.md#ace-021)
 - ケーススタディの根拠: Issue #311 / commit `6ea43f8`（Obsidian 導入、PR を経ずに develop へ直 commit）/ PR #403（Obsidian 撤退）
 
 ---
@@ -174,7 +174,7 @@ Obsidian / Notion / Hugo / Jekyll 等、**特定のアプリケーションが�
 - 自動生成ツールは「特定ツール依存物」の典型例である（P3）
 - 撤退コスト試算は「導入してから 2 週間評価」より早期に撤退判断を可能にする（P5）
 
-詳細な再発防止知見: [PLAYBOOK.md](../docs-template/08-knowledge/PLAYBOOK.md) ACE-020 / ACE-021 / ACE-022
+詳細な再発防止知見: [ACE-020](../docs-template/08-knowledge/PLAYBOOK.md#ace-020) / [ACE-021](../docs-template/08-knowledge/PLAYBOOK.md#ace-021) / [ACE-022](../docs-template/08-knowledge/PLAYBOOK.md#ace-022)
 
 ---
 
@@ -182,11 +182,11 @@ Obsidian / Notion / Hugo / Jekyll 等、**特定のアプリケーションが�
 
 3 タイミングで設計原則違反を catch する仕組みを持つ:
 
-| タイミング          | ガードレール                                                                                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 新機能 Issue 起票時 | [Issue テンプレ feature.md](../.github/ISSUE_TEMPLATE/feature.md) / [infra.md](../.github/ISSUE_TEMPLATE/infra.md) の「撤退コスト試算」項目                        |
-| PR 提出時           | [PR テンプレ](../.github/pull_request_template.md) の「配布境界チェック」項目                                                                                      |
-| マージ後の知見蓄積  | [PLAYBOOK.md](../docs-template/08-knowledge/PLAYBOOK.md) ACE-020（自動生成ツールの自己破壊）/ ACE-021（テンプレ配布リポ分離）/ ACE-022（削除時の取り残しチェック） |
+| タイミング          | ガードレール                                                                                                                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 新機能 Issue 起票時 | [Issue テンプレ feature.md](../.github/ISSUE_TEMPLATE/feature.md) / [infra.md](../.github/ISSUE_TEMPLATE/infra.md) の「撤退コスト試算」項目                                                                                                                              |
+| PR 提出時           | [PR テンプレ](../.github/pull_request_template.md) の「配布境界チェック」項目                                                                                                                                                                                            |
+| マージ後の知見蓄積  | [ACE-020](../docs-template/08-knowledge/PLAYBOOK.md#ace-020)（自動生成ツールの自己破壊）/ [ACE-021](../docs-template/08-knowledge/PLAYBOOK.md#ace-021)（テンプレ配布リポ分離）/ [ACE-022](../docs-template/08-knowledge/PLAYBOOK.md#ace-022)（削除時の取り残しチェック） |
 
 ## 改訂履歴
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -182,11 +182,15 @@ Obsidian / Notion / Hugo / Jekyll 等、**特定のアプリケーションが�
 
 3 タイミングで設計原則違反を catch する仕組みを持つ:
 
-| タイミング          | ガードレール                                                                                                                                                                                                                                                             |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 新機能 Issue 起票時 | [Issue テンプレ feature.md](../.github/ISSUE_TEMPLATE/feature.md) / [infra.md](../.github/ISSUE_TEMPLATE/infra.md) の「撤退コスト試算」項目                                                                                                                              |
-| PR 提出時           | [PR テンプレ](../.github/pull_request_template.md) の「配布境界チェック」項目                                                                                                                                                                                            |
-| マージ後の知見蓄積  | [ACE-020](../docs-template/08-knowledge/PLAYBOOK.md#ace-020)（自動生成ツールの自己破壊）/ [ACE-021](../docs-template/08-knowledge/PLAYBOOK.md#ace-021)（テンプレ配布リポ分離）/ [ACE-022](../docs-template/08-knowledge/PLAYBOOK.md#ace-022)（削除時の取り残しチェック） |
+| タイミング          | ガードレール                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 新機能 Issue 起票時 | [Issue テンプレ feature.md](../.github/ISSUE_TEMPLATE/feature.md) / [infra.md](../.github/ISSUE_TEMPLATE/infra.md) の「撤退コスト試算」項目 |
+| PR 提出時           | [PR テンプレ](../.github/pull_request_template.md) の「配布境界チェック」項目                                                               |
+| マージ後の知見蓄積  | [ACE-020][] / [ACE-021][] / [ACE-022][]（順に: 自動生成ツールの自己破壊 / テンプレ配布リポ分離 / 削除時の取り残しチェック）                 |
+
+[ACE-020]: ../docs-template/08-knowledge/PLAYBOOK.md#ace-020
+[ACE-021]: ../docs-template/08-knowledge/PLAYBOOK.md#ace-021
+[ACE-022]: ../docs-template/08-knowledge/PLAYBOOK.md#ace-022
 
 ## 改訂履歴
 


### PR DESCRIPTION
Closes #425

## Summary

PR #423 のレビュー指摘（code-reviewer S2 + comment-analyzer S1）への対応。PLAYBOOK.md（1344 行）の `[ACE-NNN](...)` 参照がファイルレベルリンクで特定エントリにジャンプできなかった問題を解消する。

- **PLAYBOOK.md**: ACE-001〜041 の各エントリ直前に `<a id="ace-NNN"></a>` を付与（計 41 件）
- **エントリテンプレート**: `### ACE-XXX:` の前に anchor 行を追加 + 記述ガイドラインに anchor 命名規則を明記
- **既存リンク参照を 12 箇所更新**: `[PLAYBOOK ACE-NNN](...)` / `[PLAYBOOK.md ACE-NNN](...)` / `[PLAYBOOK.md](...) ACE-NNN` の 3 形式を `[ACE-NNN](.../PLAYBOOK.md#ace-nnn)` に統一
- **新規追加時の anchor 命名規則を追記**: `ace-cycle.md` / `knowledge-management.md` / `.claude/commands/ace-curate.md`
- **Frontmatter**: version `1.18.0` → `1.19.0`

## 判断ログ（implementation-notes 転記、ACE-034）

### Decisions not in spec
- Issue 受入基準は `knowledge-management.md` / `ace-cycle.md` の 2 ファイルだけだったが、実際の追記処理は `/ace-curate` skill が行うため `.claude/commands/ace-curate.md` のテンプレも更新した（advisor 指摘）。enforcement point を mutation 側に揃えるため。
- PLAYBOOK.md の HTML コメント内サンプル（`<!-- 追記例: ... -->`）にも anchor 形式を反映した。テンプレ整合性のため。

### Changes from spec
- 受入基準は「`knowledge-management.md` / `ace-cycle.md` に anchor 命名規則を追記」だったが、実 mutation 点である `.claude/commands/ace-curate.md` にも追記した。

### Tradeoffs（採った / 捨てた）
- **採った**: 選択肢2（explicit anchor）。`<a id="ace-NNN"></a>` を見出し直前に 1 行付与。
- **捨てた**: 選択肢1（GitHub auto-anchor）— 日本語見出しは `ace-034-実装中はimplementation-notesmd...` 形式で長文かつ fragile（見出し変更で壊れる）。
- **捨てた**: 選択肢3（現状維持）— ACE-027（行番号 hard-coded を heading anchor 化する）と矛盾。Issue #425 自体が ACE-027 の延長。
- **採った**: anchor 番号は `ace-001` 小文字 + ハイフン + 3 桁ゼロパディング（GitHub auto-anchor 慣例に合わせる）。
- **採った**: PR スコープに別形式 `[PLAYBOOK ACE-NNN](...)` / `[PLAYBOOK.md ACE-NNN](...)` / `[PLAYBOOK.md](...) ACE-NNN` も含めて統一更新（追加コストが小さく一貫性が高まるため）。

### Open questions
- PLAYBOOK.md の冒頭サンプル `### ACE-001: N+1クエリ...`（HTML コメント内、テンプレ説明用）の削除は別 Issue 化推奨か？ 今 PR では anchor 反映のみで温存。

## Test plan

- [x] `npm run quality:local` 全 pass（mcp/check, vitest, validate-docs 100%, prettier, markdownlint 0 errors）
- [x] `mcp/dist/index.js --check` errors=0（indexed files=122 sections=1503）
- [x] PLAYBOOK.md の ACE-001〜041 すべてに anchor が付与されたこと確認（41/41）
- [x] 既存 ACE-NNN markdown link の anchor 不在ゼロ確認（grep）
- [ ] **Draft PR レビュー時**: GitHub renderer 上で `#ace-034` リンクをクリックして実際にジャンプすることを目視確認

## 関連

- 指摘元: PR [#423](https://github.com/feel-flow/ai-spec-driven-development/pull/423)
- 対象ファイル（SSOT）: [PLAYBOOK.md](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md)
- 関連 ACE: [ACE-016](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md#ace-016)（anchor link の label+URL 両方）/ [ACE-024](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md#ace-024)（用語統一）/ [ACE-027](https://github.com/feel-flow/ai-spec-driven-development/blob/develop/docs-template/08-knowledge/PLAYBOOK.md#ace-027)（heading anchor 化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)