### PR TITLE
fix: #417 quality:local チェーンに build:spec-index を追加し関連ドキュメントを実態と整合

### DIFF
--- a/docs/FRONTMATTER_GUIDE.md
+++ b/docs/FRONTMATTER_GUIDE.md
@@ -89,7 +89,7 @@ frontmatter の `title` / `tags` / `references` / `status` / `changeImpact` は�
 | ------------------------------ | ------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | `scripts/validate-docs.mjs`    | `docs-template/` 配下の **固定 7 ファイル**（CORE_DOCS 配列で列挙） | `title`, `version`, `status`, `owner`, `created`, `updated`           | 必須フィールド・enum・SemVer 検証。失敗で exit 1                 |
 | `scripts/build-spec-index.mjs` | `docs/specs/**/*.md`                                                | `specId`, `title`, `status`, `version`, `tags`, `links`, `metrics` 他 | `dist/spec-index.json` を生成。`specId` 重複・enum 違反で exit 1 |
-| `npm run quality:local`        | 上記の validate / lint / prettier を統括                            | 上記すべて                                                            | 旧 GitHub Actions CI 相当の品質ゲート（PR 前に手動実行）         |
+| `npm run quality:local`        | 上記の validate / build-spec-index / lint / prettier を統括         | 上記すべて                                                            | 旧 GitHub Actions CI 相当の品質ゲート（PR 前に手動実行）         |
 
 > **重要**: `validate-docs.mjs` は **CORE_DOCS 配列で列挙された 7 ファイルだけ**を検証する。拡張文書（GLOSSARY, DECISIONS 等）や `PLAYBOOK.md`、`docs/` 配下の方法論ガイド類は **CI で frontmatter 検証されない**。拡張対象にしたい場合は `CORE_DOCS` 配列への追加か別スクリプト化が必要。
 

--- a/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
+++ b/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
@@ -74,24 +74,24 @@ npm run build:spec-index
 npm run lint:md
 ```
 
-| 手順                                | 根拠（スクリプト定義先）                                                                       |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `npm ci`                            | ルート。ロックファイルに従いルート依存を再現。                                                 |
-| `npm --prefix mcp ci`               | `mcp/package.json`。MCP サーバー側の `npm ci`。                                                |
-| `npm run build:mcp`                 | ルート → `npm --prefix mcp run build`（MCP ビルド）。                                          |
-| `npm run check`                     | ルート → `mcp` の `check`（ビルド＋`--check`）。                                               |
-| `npm --prefix mcp test`             | `mcp` の Vitest。                                                                              |
-| `npm run test:ace-scripts`          | ルート、ルート `vitest run`（ACE スクリプト用テスト）。                                        |
-| `npm run validate -- docs-template` | ルート `validate` に `docs-template` 引数。                                                    |
-| `npm run build:spec-index`          | ルート → `node scripts/build-spec-index.mjs`。`docs/specs/**` 検証＋索引生成（不在で no-op）。 |
-| `npm run lint:md`                   | ルート、`markdownlint-cli2` 対象パスを指定。                                                   |
+| 手順                                | 根拠（スクリプト定義先）                                                                                                                                   |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm ci`                            | ルート。ロックファイルに従いルート依存を再現。                                                                                                             |
+| `npm --prefix mcp ci`               | `mcp/package.json`。MCP サーバー側の `npm ci`。                                                                                                            |
+| `npm run build:mcp`                 | ルート → `npm --prefix mcp run build`（MCP ビルド）。                                                                                                      |
+| `npm run check`                     | ルート → `mcp` の `check`（ビルド＋`--check`）。                                                                                                           |
+| `npm --prefix mcp test`             | `mcp` の Vitest。                                                                                                                                          |
+| `npm run test:ace-scripts`          | ルート、ルート `vitest run`（ACE スクリプト用テスト）。                                                                                                    |
+| `npm run validate -- docs-template` | ルート `validate` に `docs-template` 引数。                                                                                                                |
+| `npm run build:spec-index`          | ルート → `node scripts/build-spec-index.mjs`。`docs/specs/**` 検証＋索引生成（不在時は specs=0 で `dist/spec-index.json` を空索引として書き出し exit 0）。 |
+| `npm run lint:md`                   | ルート、`markdownlint-cli2` 対象パスを指定。                                                                                                               |
 
-**注**: ルートの `package.json` に `format:md` は**存在しません**（本設計のコマンド表および移行手順の記述では参照しません。README 等の古い表記の是正は「更新が必要なドキュメント」で扱います）。
+**注**: ルートの `package.json` には `format:md`（Prettier 書き込み）/ `format:md:check`（Prettier 検査）が存在するが、本 §3.2 は **旧 `ci.yml` のステップ順** を再現するセクションのため列挙していない（旧 `ci.yml` には Prettier ステップが含まれていなかった）。**`quality:local` の実体には `format:md:check` が含まれる**（§3.3 参照）。
 
 ### 3.3 `quality:local` npm スクリプト（実装済み）
 
 - **ルート `package.json`**: `quality:local` は **3.2 と同順**だが、**`npm ci` および `npm --prefix mcp ci` を含まない**（日々の実行時間を抑える。ロックファイル厳密再現が必要なときは手動で 3.2 冒頭の 2 ステップを先に実行する）。
-- **中身の順序**: `build:mcp` → `check` → `mcp test` → `test:ace-scripts` → `validate -- docs-template` → `build:spec-index` → `lint:md`。
+- **中身の順序**: `build:mcp` → `check` → `mcp test` → `test:ace-scripts` → `validate -- docs-template` → `build:spec-index` → `format:md:check` → `lint:md`。
 - **合意事項**: 3.2 の意図を破壊的に変えない（意図的な手順変更を除く）。
 
 ### 3.4 markdownlint（補足）

--- a/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
+++ b/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
@@ -70,26 +70,28 @@ npm run check
 npm --prefix mcp test
 npm run test:ace-scripts
 npm run validate -- docs-template
+npm run build:spec-index
 npm run lint:md
 ```
 
-| 手順                                | 根拠（スクリプト定義先）                                |
-| ----------------------------------- | ------------------------------------------------------- |
-| `npm ci`                            | ルート。ロックファイルに従いルート依存を再現。          |
-| `npm --prefix mcp ci`               | `mcp/package.json`。MCP サーバー側の `npm ci`。         |
-| `npm run build:mcp`                 | ルート → `npm --prefix mcp run build`（MCP ビルド）。   |
-| `npm run check`                     | ルート → `mcp` の `check`（ビルド＋`--check`）。        |
-| `npm --prefix mcp test`             | `mcp` の Vitest。                                       |
-| `npm run test:ace-scripts`          | ルート、ルート `vitest run`（ACE スクリプト用テスト）。 |
-| `npm run validate -- docs-template` | ルート `validate` に `docs-template` 引数。             |
-| `npm run lint:md`                   | ルート、`markdownlint-cli2` 対象パスを指定。            |
+| 手順                                | 根拠（スクリプト定義先）                                                                       |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `npm ci`                            | ルート。ロックファイルに従いルート依存を再現。                                                 |
+| `npm --prefix mcp ci`               | `mcp/package.json`。MCP サーバー側の `npm ci`。                                                |
+| `npm run build:mcp`                 | ルート → `npm --prefix mcp run build`（MCP ビルド）。                                          |
+| `npm run check`                     | ルート → `mcp` の `check`（ビルド＋`--check`）。                                               |
+| `npm --prefix mcp test`             | `mcp` の Vitest。                                                                              |
+| `npm run test:ace-scripts`          | ルート、ルート `vitest run`（ACE スクリプト用テスト）。                                        |
+| `npm run validate -- docs-template` | ルート `validate` に `docs-template` 引数。                                                    |
+| `npm run build:spec-index`          | ルート → `node scripts/build-spec-index.mjs`。`docs/specs/**` 検証＋索引生成（不在で no-op）。 |
+| `npm run lint:md`                   | ルート、`markdownlint-cli2` 対象パスを指定。                                                   |
 
 **注**: ルートの `package.json` に `format:md` は**存在しません**（本設計のコマンド表および移行手順の記述では参照しません。README 等の古い表記の是正は「更新が必要なドキュメント」で扱います）。
 
 ### 3.3 `quality:local` npm スクリプト（実装済み）
 
 - **ルート `package.json`**: `quality:local` は **3.2 と同順**だが、**`npm ci` および `npm --prefix mcp ci` を含まない**（日々の実行時間を抑える。ロックファイル厳密再現が必要なときは手動で 3.2 冒頭の 2 ステップを先に実行する）。
-- **中身の順序**: `build:mcp` → `check` → `mcp test` → `test:ace-scripts` → `validate -- docs-template` → `lint:md`。
+- **中身の順序**: `build:mcp` → `check` → `mcp test` → `test:ace-scripts` → `validate -- docs-template` → `build:spec-index` → `lint:md`。
 - **合意事項**: 3.2 の意図を破壊的に変えない（意図的な手順変更を除く）。
 
 ### 3.4 markdownlint（補足）

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:spec-index": "node scripts/build-spec-index.mjs",
     "test": "npm --prefix mcp test && npm run test:ace-scripts",
     "test:ace-scripts": "vitest run",
-    "quality:local": "npm run build:mcp && npm run check && npm --prefix mcp test && npm run test:ace-scripts && npm run validate -- docs-template && npm run format:md:check && npm run lint:md",
+    "quality:local": "npm run build:mcp && npm run check && npm --prefix mcp test && npm run test:ace-scripts && npm run validate -- docs-template && npm run build:spec-index && npm run format:md:check && npm run lint:md",
     "ace:check-playbook-categories": "npx --yes tsx docs-template/scripts/ace/check-category-size.ts docs-template/08-knowledge/PLAYBOOK.md",
     "setup:labels": "bash scripts/setup-github-labels.sh",
     "prepare": "husky"


### PR DESCRIPTION
## Summary

`npm run quality:local` のチェーンに `build:spec-index` が含まれていなかったため、`docs/FRONTMATTER_GUIDE.md` §2 表の「validate / lint / prettier を統括」という記述が事実と乖離していた問題を Option A（チェーン追加＋ドキュメント整合）で解消する。

- PR #416 Toolkit code-reviewer 検出、PR #414 から残存していた pre-existing な不整合
- `build-spec-index.mjs` は `SPEC_DIR` 不在時 (`walkMarkdown` で空配列) に exit 0 で抜けるため、spec を持たないプロジェクトでも安全

## Changes

- `package.json`: `quality:local` チェーンの `validate -- docs-template` と `format:md:check` の間に `npm run build:spec-index` を挿入。`specId` 重複・`status` enum 違反検出が品質ゲートに含まれる。
- `docs/FRONTMATTER_GUIDE.md` §2 表: `quality:local` 行の説明を `validate / build-spec-index / lint / prettier を統括` に更新。
- `docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.2-3.3: CI 相当順の bash ブロック・表・「中身の順序」記述に `build:spec-index` を追加。

## Test plan

- [x] `npm run build:spec-index` 単体で既存 spec (`docs/specs/authentication.md`, `spec-template.md`) が `specs=2 errors=0` で通る
- [x] `npm run quality:local` フル実行が落ちずに完了する（prettier の自動整形を含めて反映済み）
- [x] markdownlint・prettier 共に 0 error

Closes #417