### PR TITLE
docs: #430 README/PRテンプレの quality:local 記述を実態と整合

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@
 
 ## Self-Review Results
 
-- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](../docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md)）
+- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](../docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md#quality-local-detail)）
 - [ ] `markdownlint`: 該当 Markdown に問題なし（Husky pre-commit と整合）
 - [ ] MCP: `npm run check` 相当でエラーなし（該当する場合）
 - [ ] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts`（該当する場合）がパス

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,7 @@
 
 ## Self-Review Results
 
-- [ ] **ローカル品質ゲート**（旧 CI 相当: 依存を最新にしたうえで `npm ci` → `npm --prefix mcp ci` → `npm run build:mcp` → `npm run check` → `npm --prefix mcp test` → `npm run test:ace-scripts` → `npm run validate -- docs-template` → `npm run lint:md`）を **PR 提出前**に実行し、**失敗がない**ことを確認した
-- [ ] または、ルートの **`npm run quality:local`**（上記と同順で、`npm ci` / `mcp ci` を除く）を実行し、**失敗がない**ことを確認した
+- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](../docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md)）
 - [ ] `markdownlint`: 該当 Markdown に問題なし（Husky pre-commit と整合）
 - [ ] MCP: `npm run check` 相当でエラーなし（該当する場合）
 - [ ] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts`（該当する場合）がパス

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ PR マージ後の `/ace-curate` 手動実行を、**別プロセスの subagent
 
 ### 利用可能なコマンド
 
-| コマンド                             | 説明                                                                                                                                                                               |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `npm run setup`                      | 依存関係インストール + MCP サーバービルド                                                                                                                                          |
-| `npm run validate`                   | コア7文書の存在と構造の検証                                                                                                                                                        |
-| `npm run check`                      | MCP サーバーの動作確認                                                                                                                                                             |
-| `npm run build:mcp`                  | MCP サーバーのビルド                                                                                                                                                               |
-| `npm run quality:local`              | PR 前のローカル品質ゲート（`npm ci` / `mcp ci` は含まない。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md`](./docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md) §3.3 参照） |
-| `npm run lint:md`                    | markdownlint（従来 CI と同条件のパス指定）                                                                                                                                         |
-| `npm run format:md`                  | Markdown を Prettier で整形（`docs/`、`docs-template/`、ルート `*.md`）                                                                                                            |
-| `npm run format:md:check`            | Markdown が Prettier 整形済みかを検査（CI / pre-commit 用）                                                                                                                        |
-| `npm run setup:labels`               | GitHub ラベルの自動セットアップ                                                                                                                                                    |
-| `bash scripts/setup-multi-review.sh` | Multi-CLI Review Agent のセットアップ                                                                                                                                              |
+| コマンド                             | 説明                                                                                                                                                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run setup`                      | 依存関係インストール + MCP サーバービルド                                                                                                                                                                            |
+| `npm run validate`                   | コア7文書の存在と構造の検証                                                                                                                                                                                          |
+| `npm run check`                      | MCP サーバーの動作確認                                                                                                                                                                                               |
+| `npm run build:mcp`                  | MCP サーバーのビルド                                                                                                                                                                                                 |
+| `npm run quality:local`              | PR 前のローカル品質ゲート（`npm ci` / `npm --prefix mcp ci` は含まない。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](./docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md#quality-local-detail) 参照） |
+| `npm run lint:md`                    | markdownlint（従来 CI と同条件のパス指定）                                                                                                                                                                           |
+| `npm run format:md`                  | Markdown を Prettier で整形（`docs/`、`docs-template/`、ルート `*.md`）                                                                                                                                              |
+| `npm run format:md:check`            | Markdown が Prettier 整形済みかを検査（CI / pre-commit 用）                                                                                                                                                          |
+| `npm run setup:labels`               | GitHub ラベルの自動セットアップ                                                                                                                                                                                      |
+| `bash scripts/setup-multi-review.sh` | Multi-CLI Review Agent のセットアップ                                                                                                                                                                                |
 
 品質ゲートの全体像・リリース手動フローは [docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md](./docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ PR マージ後の `/ace-curate` 手動実行を、**別プロセスの subagent
 
 ### 利用可能なコマンド
 
-| コマンド                             | 説明                                                                             |
-| ------------------------------------ | -------------------------------------------------------------------------------- |
-| `npm run setup`                      | 依存関係インストール + MCP サーバービルド                                        |
-| `npm run validate`                   | コア7文書の存在と構造の検証                                                      |
-| `npm run check`                      | MCP サーバーの動作確認                                                           |
-| `npm run build:mcp`                  | MCP サーバーのビルド                                                             |
-| `npm run quality:local`              | PR 前の品質ゲート（旧 `CI` ワークフローと同順。`npm ci` および `mcp ci` は未含） |
-| `npm run lint:md`                    | markdownlint（従来 CI と同条件のパス指定）                                       |
-| `npm run format:md`                  | Markdown を Prettier で整形（`docs/`、`docs-template/`、ルート `*.md`）          |
-| `npm run format:md:check`            | Markdown が Prettier 整形済みかを検査（CI / pre-commit 用）                      |
-| `npm run setup:labels`               | GitHub ラベルの自動セットアップ                                                  |
-| `bash scripts/setup-multi-review.sh` | Multi-CLI Review Agent のセットアップ                                            |
+| コマンド                             | 説明                                                                                                                                                                               |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `npm run setup`                      | 依存関係インストール + MCP サーバービルド                                                                                                                                          |
+| `npm run validate`                   | コア7文書の存在と構造の検証                                                                                                                                                        |
+| `npm run check`                      | MCP サーバーの動作確認                                                                                                                                                             |
+| `npm run build:mcp`                  | MCP サーバーのビルド                                                                                                                                                               |
+| `npm run quality:local`              | PR 前のローカル品質ゲート（`npm ci` / `mcp ci` は含まない。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md`](./docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md) §3.3 参照） |
+| `npm run lint:md`                    | markdownlint（従来 CI と同条件のパス指定）                                                                                                                                         |
+| `npm run format:md`                  | Markdown を Prettier で整形（`docs/`、`docs-template/`、ルート `*.md`）                                                                                                            |
+| `npm run format:md:check`            | Markdown が Prettier 整形済みかを検査（CI / pre-commit 用）                                                                                                                        |
+| `npm run setup:labels`               | GitHub ラベルの自動セットアップ                                                                                                                                                    |
+| `bash scripts/setup-multi-review.sh` | Multi-CLI Review Agent のセットアップ                                                                                                                                              |
 
 品質ゲートの全体像・リリース手動フローは [docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md](./docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md) を参照してください。
 

--- a/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
+++ b/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md
@@ -88,6 +88,8 @@ npm run lint:md
 
 **注**: ルートの `package.json` には `format:md`（Prettier 書き込み）/ `format:md:check`（Prettier 検査）が存在するが、本 §3.2 は **旧 `ci.yml` のステップ順** を再現するセクションのため列挙していない（旧 `ci.yml` には Prettier ステップが含まれていなかった）。**`quality:local` の実体には `format:md:check` が含まれる**（§3.3 参照）。
 
+<a id="quality-local-detail"></a>
+
 ### 3.3 `quality:local` npm スクリプト（実装済み）
 
 - **ルート `package.json`**: `quality:local` は **3.2 と同順**だが、**`npm ci` および `npm --prefix mcp ci` を含まない**（日々の実行時間を抑える。ロックファイル厳密再現が必要なときは手動で 3.2 冒頭の 2 ステップを先に実行する）。
@@ -223,8 +225,7 @@ npm run lint:md
 
 ## Self-Review Results
 
-- [ ] **ローカル品質ゲート**（CI 相当: `npm ci` → `npm --prefix mcp ci` → `npm run build:mcp` → `npm run check` → `npm --prefix mcp test` → `npm run test:ace-scripts` → `npm run validate -- docs-template` → `npm run lint:md`）を **PR 提出前**に実行し、**失敗がない**ことを確認した
-- [ ] または、**`npm run quality:local`** で同等の確認をした
+- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [§3.3](#quality-local-detail)）
 - [ ] `markdownlint`: 該当 Markdown に問題なし（Husky pre-commit と整合）
 - [ ] MCP: `npm run check` 相当でエラーなし（該当する場合）
 - [ ] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts`（該当する場合）がパス


### PR DESCRIPTION
## Summary

- PR #429（Issue #417 対応）で `quality:local` チェーンに `build:spec-index` を追加した結果、別ファイルに残っていた旧チェーン記述が stale に。
- Issue #430 でスコープ外として切り出した「README.md:74」と「.github/pull_request_template.md:28-29」の 2 箇所を、`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3 を SSOT とする形に整合。

## PR Size Check

- 差分: **27** 行（追加 13 + 削除 14、Prettier によるテーブル再整形を含む）

- [x] 200 行以下 — 推奨レンジ（即レビュー可能）
- [ ] 201〜400 行
- [ ] 401 行以上

## Changes

### Updated: `README.md`

- L74: `npm run quality:local` セルの説明を「旧 `CI` ワークフローと同順」から「ローカル品質ゲート（`npm ci` / `mcp ci` は含まない。実体チェーンは `docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3 参照）」に緩和。
- Prettier 自動再整形によりテーブル全体のセル幅を再調整（内容差分は L74 のみ）。

### Updated: `.github/pull_request_template.md`

- L28-29: 旧 CI チェーン列挙 + `quality:local` への置換案の 2 行構成を、`npm run quality:local` 1 行呼びに簡略化。
  - `npm ci` / `npm --prefix mcp ci` の escape hatch は注釈として保持。
  - 実体チェーンの SSOT を `docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3 に一本化（チェーン変更時の更新箇所が減る）。

> **注**: `docs-template/.github/pull_request_template.md`（配布版）は構造が異なる汎用版で本件チェーン記述を持たないため同期不要。配布境界違反なし。

## Self-Review Results

- [x] **ローカル品質ゲート**: `npm run quality:local`（`build:mcp` → `check` → `mcp test` → `test:ace-scripts` → `validate -- docs-template` → `build:spec-index` → `format:md:check` → `lint:md`）パス
- [x] `markdownlint`: パス（Husky pre-commit と整合）
- [x] MCP: `npm run check` 相当パス
- [x] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts` パス

> **注**: リモート **GitHub Actions** に依存しない方針のため、**マージ前の品質はローカル実行＋本チェックリスト**を前提とする。

### Cross-Model Review Results

- [ ] PR Review Toolkit: 実施予定
- [ ] GitHub Copilot review: 実施予定（MCP 経由で並列起動）
- [ ] [Review Response Policy](docs-template/05-operations/deployment/review-response-policy.md) に従い対応予定

## Test plan

- [x] `npm run quality:local` が引き続き通る（品質ゲートを動かす変更ではないので回帰しないはず）
- [x] README のテーブルが Prettier 整形済み（`format:md:check` パス）
- [x] PR テンプレの新文言で `npm run quality:local` が単独で品質ゲートとして案内されている

## 配布境界チェック

- [x] **該当なし** — `docs-template/` 配下を変更していない（リポ本体の README と `.github/pull_request_template.md` のみ）

## Related Issue

Closes #430