### PR TITLE
fix: #434 PRテンプレの相対リンクを blob/HEAD 絶対 URL に修正

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 - [ ] 201〜400 行 — ⚠️ レビュー見落としリスク増加（理由を Summary に記載）
 - [ ] 401 行以上 — 🚨 原則として分割推奨（分割不可の理由 / レビュー観点ガイドを以下に記載）
 
-> **目安**: 1 機能あたり 200 行以下を推奨。400 行を超える場合はマージ前に分割を検討するか、分割困難な場合は **レビュー観点ガイド**（読む順序・前提コンテキスト・重点確認箇所）を Summary に明記する。詳細: [docs/AI_GIT_WORKFLOW.md#ステップ6-pr作成](../docs/AI_GIT_WORKFLOW.md#ステップ6-pr作成)。
+> **目安**: 1 機能あたり 200 行以下を推奨。400 行を超える場合はマージ前に分割を検討するか、分割困難な場合は **レビュー観点ガイド**（読む順序・前提コンテキスト・重点確認箇所）を Summary に明記する。詳細: [docs/AI_GIT_WORKFLOW.md#ステップ6-pr作成](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/AI_GIT_WORKFLOW.md#ステップ6-pr作成)。
 
 ## Changes
 
@@ -25,7 +25,7 @@
 
 ## Self-Review Results
 
-- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](../docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md#quality-local-detail)）
+- [ ] **ローカル品質ゲート**: `npm run quality:local` を **PR 提出前** に実行し、**失敗がない** ことを確認した（依存ロック厳密再現が必要な場合は事前に `npm ci` / `npm --prefix mcp ci`。実体チェーンは [`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md` §3.3](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md#quality-local-detail)）
 - [ ] `markdownlint`: 該当 Markdown に問題なし（Husky pre-commit と整合）
 - [ ] MCP: `npm run check` 相当でエラーなし（該当する場合）
 - [ ] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts`（該当する場合）がパス
@@ -51,7 +51,7 @@
 - [ ] 型安全性を確保（該当する場合）
 - [ ] リンク切れがない
 
-## 配布境界チェック（[DESIGN_PRINCIPLES.md](../docs/DESIGN_PRINCIPLES.md) P2/P3）
+## 配布境界チェック（[DESIGN_PRINCIPLES.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/DESIGN_PRINCIPLES.md) P2/P3）
 
 > `docs-template/` 配下を変更している PR では必ず確認。それ以外は該当なしで OK。
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@
 
 - [ ] PR Review Toolkit: 実施済み
 - [ ] Codex CLI (`bash scripts/codex-review.sh --branch`): 実施済み
-- [ ] [Review Response Policy](docs-template/05-operations/deployment/review-response-policy.md) に従い対応済み
+- [ ] [Review Response Policy](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/05-operations/deployment/review-response-policy.md) に従い対応済み
 
 ## Test plan
 
@@ -51,7 +51,7 @@
 - [ ] 型安全性を確保（該当する場合）
 - [ ] リンク切れがない
 
-## 配布境界チェック（[DESIGN_PRINCIPLES.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/DESIGN_PRINCIPLES.md) P2/P3）
+## 配布境界チェック（[docs/DESIGN_PRINCIPLES.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/DESIGN_PRINCIPLES.md) P2/P3）
 
 > `docs-template/` 配下を変更している PR では必ず確認。それ以外は該当なしで OK。
 


### PR DESCRIPTION
親 Issue #433 子 Issue A の対応。Gemini Code Assist が PR #431 で指摘した本筋。

## Summary

- PR #431 で Gemini 指摘 → `../docs/X.md` は PR body 展開時に `repo/docs/X.md` に解決され HTTP 404 になることを実証。
- `blob/HEAD/docs/X.md` 絶対 URL に置換すれば 200 で動作。`HEAD` は default branch を自動追跡するため branch hardcode 問題なし。

実証データの全体像は親 Issue #433 参照。

## PR Size Check

- 差分: **6** 行（追加 3 + 削除 3）

- [x] 200 行以下 — 推奨レンジ（即レビュー可能）

## Changes

### Updated: `.github/pull_request_template.md`

- L15: `[docs/AI_GIT_WORKFLOW.md#ステップ6-pr作成](../docs/...)` → `(.../blob/HEAD/docs/...)`
- L28: `[\`docs/NO_GITHUB_ACTIONS_MIGRATION_DESIGN.md\` §3.3](../docs/...)` → `(.../blob/HEAD/docs/...)`
- L54: `[DESIGN_PRINCIPLES.md](../docs/...)` → `(.../blob/HEAD/docs/...)`

## Self-Review Results

- [x] **ローカル品質ゲート**: `npm run quality:local` パス
- [x] `markdownlint`: パス
- [x] MCP: `npm run check` パス
- [x] テスト: `npm --prefix mcp test` および `npm run test:ace-scripts` パス（quality:local チェーン内で実行）

### Cross-Model Review Results

- [ ] PR Review Toolkit: 実施予定
- [ ] GitHub Copilot review: 実施予定
- [ ] [Review Response Policy](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/05-operations/deployment/review-response-policy.md) に従い対応予定

## Test plan

- [x] `npm run quality:local` パス
- [ ] PR body 展開後にこの PR の Summary 内 `#433` リンクが GitHub 上で 200 で開けることを確認
- [ ] マージ後、新規 PR でテンプレを展開した body 内のリンクが 200 で開けることを確認

## 配布境界チェック

- [x] **該当なし** — `.github/pull_request_template.md` のみ変更（リポ固有の絶対 URL 採用のため `docs-template/.github/pull_request_template.md` への同期は不要。配布版は子 Issue #435 で別アプローチ＝plain text 化で対応）

## Related Issue

Closes #434
Parent: #433