### PR TITLE
fix: #436 Issueテンプレ16箇所の相対リンクを blob/HEAD 絶対 URL に修正

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -29,7 +29,7 @@ assignees: ''
 > **必須参照**: 関連Issue, PATTERNS
 
 - [ ] #XX [関連する過去のIssue]
-- [ ] [PATTERNS.md#エラーハンドリング](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/03-implementation/PATTERNS.md)
+- [ ] [PATTERNS.md#エラーハンドリング](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/03-implementation/PATTERNS.md#エラーハンドリング)
 
 > **推奨参照**: TESTING
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -29,11 +29,11 @@ assignees: ''
 > **必須参照**: 関連Issue, PATTERNS
 
 - [ ] #XX [関連する過去のIssue]
-- [ ] [PATTERNS.md#エラーハンドリング](../../docs-template/03-implementation/PATTERNS.md)
+- [ ] [PATTERNS.md#エラーハンドリング](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/03-implementation/PATTERNS.md)
 
 > **推奨参照**: TESTING
 
-- [ ] [TESTING.md](../../docs-template/04-quality/TESTING.md)
+- [ ] [TESTING.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/04-quality/TESTING.md)
 
 ## 関連Issue
 

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -24,7 +24,7 @@ assignees: ''
 
 > **必須参照**: MASTER
 
-- [ ] [MASTER.md](../../docs-template/MASTER.md)
+- [ ] [MASTER.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/MASTER.md)
 
 > **対象文書**
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -18,14 +18,14 @@ assignees: ""
 
 > **必須参照**: MASTER, ARCHITECTURE, DOMAIN
 
-- [ ] [MASTER.md](../../docs-template/MASTER.md)
-- [ ] [ARCHITECTURE.md#該当セクション](../../docs-template/02-design/ARCHITECTURE.md)
-- [ ] [DOMAIN.md#該当セクション](../../docs-template/02-design/DOMAIN.md)
+- [ ] [MASTER.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/MASTER.md)
+- [ ] [ARCHITECTURE.md#該当セクション](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/ARCHITECTURE.md)
+- [ ] [DOMAIN.md#該当セクション](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/DOMAIN.md)
 
 > **推奨参照**: PATTERNS, TESTING
 
-- [ ] [PATTERNS.md](../../docs-template/03-implementation/PATTERNS.md)
-- [ ] [TESTING.md](../../docs-template/04-quality/TESTING.md)
+- [ ] [PATTERNS.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/03-implementation/PATTERNS.md)
+- [ ] [TESTING.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/04-quality/TESTING.md)
 
 ## 関連Issue
 
@@ -61,7 +61,7 @@ assignees: ""
 - DEPLOYMENT.md（インフラ変更なし）
 - [その他、今回やらないこと]
 
-## 撤退コスト試算（[DESIGN_PRINCIPLES.md](../../docs/DESIGN_PRINCIPLES.md) P5）
+## 撤退コスト試算（[docs/DESIGN_PRINCIPLES.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/DESIGN_PRINCIPLES.md) P5）
 
 > 新機能・新ツール・新インフラを導入する Issue では、**「採用しないことになった場合に削除対象となる範囲」を着手前に見積もる**。撤退コスト > 採用メリット × 期待値 なら採用しない判断が正しい。
 

--- a/.github/ISSUE_TEMPLATE/infra.md
+++ b/.github/ISSUE_TEMPLATE/infra.md
@@ -18,12 +18,12 @@ assignees: ''
 
 > **必須参照**: MASTER, DEPLOYMENT
 
-- [ ] [MASTER.md](../../docs-template/MASTER.md)
-- [ ] [DEPLOYMENT.md](../../docs-template/05-operations/DEPLOYMENT.md)
+- [ ] [MASTER.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/MASTER.md)
+- [ ] [DEPLOYMENT.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/05-operations/DEPLOYMENT.md)
 
 > **推奨参照**: ARCHITECTURE
 
-- [ ] [ARCHITECTURE.md#インフラ](../../docs-template/02-design/ARCHITECTURE.md)
+- [ ] [ARCHITECTURE.md#インフラ](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/ARCHITECTURE.md)
 
 ## 関連Issue
 
@@ -67,7 +67,7 @@ assignees: ''
 
 [問題が発生した場合の切り戻し方法]
 
-## 撤退コスト試算（[DESIGN_PRINCIPLES.md](../../docs/DESIGN_PRINCIPLES.md) P5）
+## 撤退コスト試算（[docs/DESIGN_PRINCIPLES.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/DESIGN_PRINCIPLES.md) P5）
 
 > 新ツール・新インフラを導入する場合、**「採用しないことになった場合に削除対象となる範囲」を着手前に見積もる**。インフラ系は依存が広がりやすく、撤退コストが大きくなりがち。
 

--- a/.github/ISSUE_TEMPLATE/infra.md
+++ b/.github/ISSUE_TEMPLATE/infra.md
@@ -23,7 +23,7 @@ assignees: ''
 
 > **推奨参照**: ARCHITECTURE
 
-- [ ] [ARCHITECTURE.md#インフラ](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/ARCHITECTURE.md)
+- [ ] [ARCHITECTURE.md#インフラ](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/ARCHITECTURE.md#インフラ)
 
 ## 関連Issue
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -24,12 +24,12 @@ assignees: ''
 
 > **必須参照**: ARCHITECTURE, PATTERNS
 
-- [ ] [ARCHITECTURE.md](../../docs-template/02-design/ARCHITECTURE.md)
-- [ ] [PATTERNS.md](../../docs-template/03-implementation/PATTERNS.md)
+- [ ] [ARCHITECTURE.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/02-design/ARCHITECTURE.md)
+- [ ] [PATTERNS.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/03-implementation/PATTERNS.md)
 
 > **推奨参照**: TESTING
 
-- [ ] [TESTING.md](../../docs-template/04-quality/TESTING.md)
+- [ ] [TESTING.md](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/04-quality/TESTING.md)
 
 ## 関連Issue
 


### PR DESCRIPTION
親 Issue #433 子 Issue B の対応。PR #437 ([fix: #434](https://github.com/feel-flow/ai-spec-driven-development/pull/437)) と同じ方針で `.github/ISSUE_TEMPLATE/` 配下を一括修正。

## Summary

- PR #431 で実証された通り、`../docs/` や `../../docs-template/` は PR/Issue body 展開時に `pull/N/` または `issues/N/` 起点で解決され HTTP 404 になる。
- `blob/HEAD/` 絶対 URL に置換すれば 200 で動作。`HEAD` は default branch を自動追跡するため branch hardcode 問題なし。
- 実証データの全体像は親 Issue #433 参照。

## PR Size Check

- 差分: **32** 行（追加 16 + 削除 16、純粋な置換）

- [x] 200 行以下 — 推奨レンジ（即レビュー可能）

## Changes

### Updated: `.github/ISSUE_TEMPLATE/`

| ファイル | 箇所数 | 行番号 |
|---|---|---|
| `bug.md` | 2 | L32, L36 |
| `feature.md` | 6 | L21, L22, L23, L27, L28, L64 |
| `refactor.md` | 3 | L27, L28, L32 |
| `infra.md` | 4 | L21, L22, L26, L70 |
| `docs.md` | 1 | L27 |
| **合計** | **16** | |

置換パターン:
- `../../docs-template/X` → `https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/X`
- `../../docs/X` → `https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs/X`

`feature.md` L64 / `infra.md` L70 の `DESIGN_PRINCIPLES.md` リンクは PR #437 と同じくアンカーテキストも `docs/DESIGN_PRINCIPLES.md` に統一（リンク先パスを可視化）。

## Self-Review Results

- [x] **ローカル品質ゲート**: `npm run quality:local` パス（validate 100% / prettier OK / markdownlint 0 エラー / ACE スクリプトテストパス）
- [x] `markdownlint`: `.github/ISSUE_TEMPLATE/*.md` 5 ファイルともパス（pre-commit hook で確認）
- [x] MCP: `npm run check` パス（pre-push hook で確認、specs=2 errors=0）
- [x] 残存検証: `grep -rn "\.\./\.\./docs" .github/ISSUE_TEMPLATE/` → 0 件
- [x] 置換数検証: `grep -rn "blob/HEAD/" .github/ISSUE_TEMPLATE/` → 16 件（指定数と一致）

### Cross-Model Review Results

- [ ] PR Review Toolkit: 実施予定
- [ ] GitHub Copilot review: 実施予定
- [ ] [Review Response Policy](https://github.com/feel-flow/ai-spec-driven-development/blob/HEAD/docs-template/05-operations/deployment/review-response-policy.md) に従い対応予定

## Test plan

- [x] `npm run quality:local` パス
- [ ] このPR body 展開後に `#433` / `#437` 参照が GitHub 上で 200 で開けることを確認（PR body のリンク resolution 確認）
- [ ] マージ後、`bug` / `feature` / `refactor` / `infra` / `docs` テンプレートから新規 Issue を作成し、展開された body 内のリンクがすべて 200 で開けることを確認（任意・運用時で OK）

## 配布境界チェック

- [x] **該当なし** — `.github/ISSUE_TEMPLATE/` のみ変更（リポ固有の絶対 URL 採用のため `docs-template/.github/ISSUE_TEMPLATE/` への同期は不要。配布版は子 Issue #435 で別アプローチ＝plain text 化で対応予定）

## Related Issue

Closes #436
Parent: #433
Sibling: #434 (PR #437 でマージ済み) / #435