### PR TITLE
docs: #442 ACE運用ルールテンプレを tool-agnostic 化＋PRスコープ式採番を全AIエージェント設定（Copilot/Cursor/Codex）へ反映

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -79,6 +79,7 @@ Always start from an Issue and follow the full flow:
 6. **Commit** - `<type>: #<issue> <subject>`
 7. **Create PR** - `gh pr create --base develop`
 8. **Merge & Cleanup** - Squash merge, return to `develop`, delete feature branch
+9. **ACE (Knowledge)** - マージ・cleanup 後に PLAYBOOK.md へ知見を追記。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（並行採番でも衝突しない）。採番ルールの SSOT は `docs-template/08-knowledge/PLAYBOOK.md` の §エントリID規則、運用ルールは `docs/ACE_SETUP.md` §4 テンプレート
 
 ### Branch Naming
 - `feature/#{issue}-{description}` for features

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -196,7 +196,7 @@ When reviewing pull requests, GitHub Copilot MUST follow these rules:
 
 PR作成後、マージ前に `@review-router` エージェントを呼び出して包括的なレビューを実施します。
 
-**ワークフロー**: Issue → Branch → Commit → Self-Review → PR → **@review-router** → Review → Merge
+**ワークフロー**: Issue → Branch → Commit → Self-Review → PR → **@review-router** → Review → Merge → cleanup → **ACE（知見体系化）**
 
 **使用方法**:
 
@@ -213,6 +213,10 @@ PR作成後、マージ前に `@review-router` エージェントを呼び出し
 - Code Simplification（複雑なコード検出時）
 
 詳細は `.github/agents/review-router.agent.md` を参照。
+
+### ACE（知見体系化）
+
+マージ・cleanup 後に PR から知見を抽出し PLAYBOOK.md に追記します。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（並行採番でも衝突しない）。採番ルールの SSOT は `docs-template/08-knowledge/PLAYBOOK.md` の §エントリID規則、運用ルール本体は `docs/ACE_SETUP.md` §4 テンプレート。
 
 ## Code Review Checklist
 - [ ] AGENTS.md common rules followed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,7 +341,9 @@ Always reference MASTER.md for project-specific requirements.
 
 ### 4. Git Workflow・セルフレビュー
 
-**基本フロー**: Issue作成 → Branch作成 → 実装 → セルフレビュー → テスト → Commit → PR作成 → **@review-router でAIレビュー** → マージ後ブランチ削除
+**基本フロー**: Issue作成 → Branch作成 → 実装 → セルフレビュー → テスト → Commit → PR作成 → **@review-router でAIレビュー** → マージ → cleanup → **ACE 知見体系化**
+
+**ACE（知見体系化）**: マージ・cleanup 後に PR から知見を抽出し PLAYBOOK.md に追記する。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（並行採番でも衝突しない）。採番ルールの SSOT は [PLAYBOOK.md §エントリID規則](docs-template/08-knowledge/PLAYBOOK.md#エントリid規則)、運用ルール本体は [ACE_SETUP.md §4 テンプレート](docs/ACE_SETUP.md#ace-ops-template)。
 
 **ブランチ命名**: `feature/#{issue}-{description}` / `fix/#{issue}-{description}` / `chore/#{issue}-{description}`
 

--- a/docs-template/SETUP_CLAUDE_CODE.md
+++ b/docs-template/SETUP_CLAUDE_CODE.md
@@ -760,6 +760,7 @@ Claude Code のセットアップは以下の3ステップ：
 1. ✅ Claude Code のセットアップ完了
 2. → [GETTING_STARTED_NEW_PROJECT.md](./GETTING_STARTED_NEW_PROJECT.md) で実際のプロジェクト開始
 3. → [docs-template/MASTER.md](./MASTER.md) で詳細なプロジェクトルール確認
+4. → [ACE サイクル運用手順](./05-operations/deployment/ace-cycle.md) でマージ後の知見体系化を設定。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（採番ルールの SSOT は [エントリID規則](./08-knowledge/PLAYBOOK.md#エントリid規則)）
 
 ---
 

--- a/docs-template/SETUP_CURSOR.md
+++ b/docs-template/SETUP_CURSOR.md
@@ -717,6 +717,7 @@ Cursor のセットアップは以下の4ステップ：
 1. ✅ Cursor のセットアップ完了
 2. → [GETTING_STARTED_NEW_PROJECT.md](./GETTING_STARTED_NEW_PROJECT.md) で実際のプロジェクト開始
 3. → [docs-template/MASTER.md](./MASTER.md) で詳細なプロジェクトルール確認
+4. → [ACE サイクル運用手順](./05-operations/deployment/ace-cycle.md) でマージ後の知見体系化を設定。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（採番ルールの SSOT は [エントリID規則](./08-knowledge/PLAYBOOK.md#エントリid規則)）
 
 ### Cursorの強み
 

--- a/docs-template/SETUP_GITHUB_COPILOT.md
+++ b/docs-template/SETUP_GITHUB_COPILOT.md
@@ -281,6 +281,7 @@ your-project/
 
 - [GETTING_STARTED_NEW_PROJECT.md](./GETTING_STARTED_NEW_PROJECT.md) - プロジェクト開始ガイド
 - [05-operations/DEPLOYMENT.md](./05-operations/DEPLOYMENT.md) - AI駆動Git Workflow
+- [ACE サイクル運用手順](./05-operations/deployment/ace-cycle.md) - マージ後の知見体系化。エントリ ID は **PRスコープ式** `ACE-<PR番号>-<連番>`（採番ルールの SSOT は [エントリID規則](./08-knowledge/PLAYBOOK.md#エントリid規則)）
 
 ---
 

--- a/docs/ACE_SETUP.md
+++ b/docs/ACE_SETUP.md
@@ -30,7 +30,7 @@ changeImpact: medium
 1. [前提条件](#1-前提条件)
 2. [対話型セットアップフロー](#2-対話型セットアップフロー)
 3. [テンプレート参照情報](#3-テンプレート参照情報)
-4. [Copilot用ACE運用ルール テンプレート](#4-copilot用ace運用ルール-テンプレート)
+4. [AIツール向け ACE 運用ルール テンプレート（Copilot / Cursor / Codex 等共通）](#ace-ops-template)
 5. [トラブルシューティング](#5-トラブルシューティング)
 
 ---
@@ -91,11 +91,12 @@ changeImpact: medium
 
 ### Step 4: AIツール固有の設定
 
-ユーザーに以下の選択肢を提示してください:
+ユーザーに対象 AI ツールを確認してください（複数選択可）:
 
-- **(a) Claude Code のみ**
-- **(b) GitHub Copilot のみ**
-- **(c) 両方**
+- **(a) Claude Code** — `/ace-curate` コマンドを使う
+- **(b) GitHub Copilot** — `.github/copilot-instructions.md` に追記
+- **(c) Cursor** — `.cursorrules` に追記
+- **(d) Codex / その他の AI エージェント** — `AGENTS.md` に追記
 
 #### Claude Code の設定
 
@@ -106,13 +107,17 @@ changeImpact: medium
   - **(a) スキップ** — 既存ファイルを維持する
   - **(b) 上書き** — テンプレートで上書きする
 
-#### GitHub Copilot の設定
+#### 指示ファイルへの ACE 運用ルール追記（GitHub Copilot / Cursor / Codex / その他）
 
-`.github/copilot-instructions.md` に ACE 運用ルールを追記します。
+利用する AI ツールの指示ファイルに [§4 AIツール向け ACE 運用ルール テンプレート](#ace-ops-template) を追記します。配置先:
 
-- **ファイルが存在しない場合**: `.github/copilot-instructions.md` を新規作成する
+- GitHub Copilot → `.github/copilot-instructions.md`
+- Cursor → `.cursorrules`
+- Codex / その他の AI エージェント（Gemini 等）→ `AGENTS.md`
+
+- **ファイルが存在しない場合**: 対象の指示ファイルを新規作成する
 - **既存ファイルの場合**: 追記前に既存内容を確認し、`## ACE` や `## ACE (Agentic Context Engineering) 運用ルール` といった ACE 関連セクションが既に存在する場合は**スキップ**する
-- 追記する内容は [4. Copilot用ACE運用ルール テンプレート](#4-copilot用ace運用ルール-テンプレート) を参照
+- 採番は **PRスコープ式**（`ACE-<PR番号>-<連番>`）。ルールの SSOT はテンプレート §4 と PLAYBOOK.md の §エントリID規則
 
 ### Step 5: 完了確認
 
@@ -156,9 +161,11 @@ changeImpact: medium
 
 ---
 
-## 4. Copilot用ACE運用ルール テンプレート
+<a id="ace-ops-template"></a>
 
-以下のテンプレートを `.github/copilot-instructions.md` に追記してください。
+## 4. AIツール向け ACE 運用ルール テンプレート（Copilot / Cursor / Codex 等共通）
+
+以下のテンプレートを、利用する AI ツールの指示ファイルに追記してください（GitHub Copilot → `.github/copilot-instructions.md`、Cursor → `.cursorrules`、Codex / その他の AI エージェント → `AGENTS.md`）。テンプレート本文はツール非依存です。
 `{{PLAYBOOK_PATH}}` は Step 2 で確認した PLAYBOOK.md のパスに置換してください。
 
 ````markdown
@@ -254,9 +261,9 @@ PLAYBOOK.md のエントリ一覧セクション末尾に新エントリを追�
 
 #### コミットメッセージ規則
 
-- 形式: `knowledge: ACE-XXX [category] [summary]`
-- 複数エントリ: `knowledge: ACE-XXX,ACE-YYY [category1,category2] [summary]`
-- カウンター更新のみ: `knowledge: ACE-XXX [category] helpful+1`
+- 形式: `knowledge: ACE-<PR番号>-<連番> [category] [summary]`（例 `knowledge: ACE-441-1 [testing] ...`）
+- 複数エントリ: `knowledge: ACE-441-1,ACE-441-2 [category1,category2] [summary]`
+- カウンター更新のみ: `knowledge: ACE-016 [category] helpful+1`
 
 ### 既存エントリ照合手順
 

--- a/docs/ACE_SETUP.md
+++ b/docs/ACE_SETUP.md
@@ -1,10 +1,10 @@
 ---
 id: ace-setup
 title: ACE セットアップガイド
-version: 1.0.0
+version: 1.1.0
 status: active
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-05-30
 owner: feel-flow
 tags: [ace, setup, knowledge-management, playbook]
 references:
@@ -128,18 +128,18 @@ changeImpact: medium
 
 以下のファイルを配置しました:
 
-| ファイル                | パス                                       | 状態     |
-| ----------------------- | ------------------------------------------ | -------- |
-| PLAYBOOK.md             | docs/08-knowledge/PLAYBOOK.md              | 新規作成 |
-| ace-cycle.md            | docs/05-operations/deployment/ace-cycle.md | 新規作成 |
-| ace-curate.md           | .claude/commands/ace-curate.md             | 新規作成 |
-| copilot-instructions.md | .github/copilot-instructions.md            | 追記     |
+| ファイル                   | パス                                                       | 状態     |
+| -------------------------- | ---------------------------------------------------------- | -------- |
+| PLAYBOOK.md                | docs/08-knowledge/PLAYBOOK.md                              | 新規作成 |
+| ace-cycle.md               | docs/05-operations/deployment/ace-cycle.md                 | 新規作成 |
+| ace-curate.md              | .claude/commands/ace-curate.md                             | 新規作成 |
+| 指示ファイル（選択ツール） | .github/copilot-instructions.md / .cursorrules / AGENTS.md | 追記     |
 
 ## 次のステップ
 
-1. PRマージ後に ACE サイクルを実行してみましょう:
+1. PRマージ・cleanup 後に ACE サイクルを実行してみましょう:
    - Claude Code: `/ace-curate` コマンドを実行
-   - Copilot: 「ACEサイクルを実行してください」と指示
+   - Copilot / Cursor / Codex 等: 指示ファイルの ACE 運用ルールに従い「ACEサイクルを実行してください」と指示
 2. ACE フレームワークの詳細は [ACE_FRAMEWORK.md](./ACE_FRAMEWORK.md) を参照
 ```
 
@@ -291,11 +291,11 @@ PLAYBOOK.md のエントリ一覧セクション末尾に新エントリを追�
 
 **対応**: Step 1 の選択肢に従い、中止またはバックアップ後に続行してください。既存の PLAYBOOK.md にエントリが蓄積されている場合は、中止を推奨します。
 
-### `.github/copilot-instructions.md` が存在しない
+### 指示ファイル（copilot-instructions.md / .cursorrules / AGENTS.md）が存在しない
 
-**原因**: GitHub Copilot の設定ファイルが未作成
+**原因**: 対象 AI ツールの指示ファイルが未作成
 
-**対応**: Step 4 で自動的に新規作成されます。特別な対応は不要です。
+**対応**: Step 4 で対象の指示ファイル（Copilot → `.github/copilot-instructions.md` / Cursor → `.cursorrules` / Codex 他 → `AGENTS.md`）が自動的に新規作成されます。特別な対応は不要です。
 
 ### ace-curate.md が既に存在する
 
@@ -312,6 +312,12 @@ PLAYBOOK.md のエントリ一覧セクション末尾に新エントリを追�
 ---
 
 ## Changelog
+
+### [1.1.0] - 2026-05-30
+
+#### 変更
+
+- §4 を tool-agnostic な「AIツール向け ACE 運用ルール テンプレート（Copilot / Cursor / Codex 等共通）」に一般化（explicit anchor `#ace-ops-template` 付与）。Step 4・Step 5・トラブルシューティングを全ツール対応に。エントリ ID の採番例・コミットメッセージ例を **PRスコープ式**（`ACE-<PR番号>-<連番>`）に更新（Issue #442 / PR #443）
 
 ### [1.0.0] - 2026-03-13
 


### PR DESCRIPTION
Closes #442

## 概要

#440 / PR #441 で導入した **PRスコープ式 ACE 採番**（`ACE-<PR番号>-<連番>`）を、Claude 側に留まらず **全 AI エージェント設定（Copilot / Cursor / Codex 等）** へ行き渡らせる。ACE 運用ルールテンプレートを tool-agnostic 化し、各ツール設定は SSOT へのポインタに統一（DRY）。

ACE-018（横断変更は全サーフェスを列挙）の系。

## 変更

| ファイル | 内容 |
| --- | --- |
| `docs/ACE_SETUP.md` | §4 を「Copilot / Cursor / Codex 等共通」テンプレに一般化。explicit anchor `#ace-ops-template` 付与でリネーム耐性確保（inbound link 2本更新）。Step4 を全ツール対応（配置先: Copilot→`.github/copilot-instructions.md` / Cursor→`.cursorrules` / Codex 他→`AGENTS.md`）。コミット例を PRスコープ式に |
| `AGENTS.md` | 作業フローに ACE 知見体系化ステップ（PRスコープ式採番、SSOT ポインタ）を追加 |
| `.cursorrules` | Git Workflow に ACE ステップ（PRスコープ式採番、SSOT ポインタ）を追加 |
| `docs-template/SETUP_CURSOR.md` / `SETUP_GITHUB_COPILOT.md` | 次のステップに ACE サイクル＋エントリID規則への参照を対称的に追加 |

## 設計原則（DRY）

採番メカニクス（「最大連番 +1」「全体の最新 ID を読まない」）の実体は **PLAYBOOK.md §エントリID規則 ＋ ACE_SETUP §4** のみに置き、他の設定ファイルは SSOT へのポインタ。grep で混入なしを検証済み。

## スコープ外
- 既存 ACE エントリ本文 / Changelog（append-only 保護）
- 個人グローバル設定 `~/.claude/CLAUDE.md`（本リポジトリ外）
- review 用 CLI スクリプト・アダプタ（ACE 知見サイクルと無関係）

## 検証
- `npm run quality:local` green（MCP build/check・両テスト・docs検証100%・prettier・markdownlint 0 error）
- DRY 不変条件 grep ✅ / anchor 整合（`#ace-ops-template` 定義・参照一致、旧 anchor 参照ゼロ）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)