### PR TITLE
feat: #453 ACE 知見の再利用計測レポートを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .DS_Store
 
 # Node
-node_modules/
-mcp/node_modules/
+node_modules
+mcp/node_modules
 npm-debug.log*
 yarn-error.log*
 

--- a/docs-template/05-operations/deployment/ace-cycle.md
+++ b/docs-template/05-operations/deployment/ace-cycle.md
@@ -284,6 +284,21 @@ git commit -m "knowledge: ACE-438-1,ACE-438-2 [performance,testing] Prisma N+1�
 
 **対応**: [PLAYBOOK.md のファイル分割ルール](../../08-knowledge/PLAYBOOK.md#ファイル分割ルール) に従ってカテゴリ別に分割
 
+### 知見が「効いているか」わからない（再利用計測）
+
+**対応**: 再利用計測レポートを実行し、Helpful カウンター（手動更新）と実際の参照実績（git log / 相互参照）の乖離を確認する。
+
+```bash
+npm run ace:reuse-report
+# 閾値の上書き（既定 90 日）
+ACE_REUSE_STALE_DAYS=120 npm run ace:reuse-report
+```
+
+- **git参照**: `knowledge:` キュレーションコミットを除くコミットの件名・本文中の ACE ID 言及数
+- **相互参照**: PLAYBOOK 内で他エントリから参照されている数
+- **Archive 候補**: 作成から閾値以上経過し、git 参照が閾値以内にないアクティブエントリ（候補の列挙のみ。アーカイブの実施は別途設計）
+- **推奨頻度**: 月次、または Playbook の行数警告が出たタイミング
+
 ### コミットメッセージの規則を忘れた
 
 **形式**: `knowledge: ACE-XXX [category] [summary]`

--- a/docs-template/scripts/ace/ace-reuse-report.test.ts
+++ b/docs-template/scripts/ace/ace-reuse-report.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   computeReuseStats,
   findArchiveCandidates,
   formatReport,
+  main,
   parseGitLog,
   parsePlaybookEntries,
+  type ReuseStats,
 } from "./ace-reuse-report";
 
 const RS = "\x1e";
@@ -43,6 +48,19 @@ const PLAYBOOK_FIXTURE = `
 
 [ACE-005](#ace-005) を参照する本文。
 
+<a id="ace-i425-1"></a>
+
+### ACE-i425-1: Issue 由来のエントリ
+
+| フィールド | 値         |
+| ---------- | ---------- |
+| Category   | process    |
+| Date       | 2026-02-01 |
+| Helpful    | 1          |
+| Status     | active     |
+
+本文。
+
 <a id="ace-100"></a>
 
 ### ACE-100: 廃止済みエントリ
@@ -62,75 +80,115 @@ function gitLogFixture(): string {
   return [
     `${RS}2026-07-01${FS}fix: ACE-005 の教訓を適用${FS}本文で ACE-005 に再度言及`,
     `${RS}2026-06-20${FS}knowledge: ACE-449-1 追加（キュレーション）${FS}ACE-449-1 と ACE-005 を含むが除外されるべき`,
-    `${RS}2026-04-01${FS}feat: 通常コミット${FS}ACE-005 参照`,
+    `${RS}2026-04-01${FS}feat: 通常コミット${FS}ACE-005 参照と ACE-i425-1 参照`,
     `${RS}2026-03-01${FS}docs: 無関係${FS}ACE-XXX プレースホルダは数えない`,
   ].join("\n");
 }
 
+function statsFor(content: string, log: string): Map<string, ReuseStats> {
+  const entries = parsePlaybookEntries(content, () => {});
+  return computeReuseStats(entries, parseGitLog(log).commits, content);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("parsePlaybookEntries", () => {
-  it("実エントリのみ抽出し、HTMLコメント内の偽エントリを除外する", () => {
-    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
-    expect(entries.map((e) => e.id)).toEqual(["ACE-005", "ACE-449-1", "ACE-100"]);
+  it("実エントリのみ抽出し、HTMLコメント内の偽エントリを除外する（ACE-i 系 ID 含む）", () => {
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE, () => {});
+    expect(entries.map((e) => e.id)).toEqual(["ACE-005", "ACE-449-1", "ACE-i425-1", "ACE-100"]);
   });
 
   it("Date / Helpful / Status をテーブルから読み取る", () => {
-    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE, () => {});
     const ace005 = entries.find((e) => e.id === "ACE-005");
     expect(ace005).toMatchObject({ date: "2026-03-15", helpful: 7, status: "active" });
+  });
+
+  it("Helpful が数値でない場合は警告して 0 に落とす（黙殺しない）", () => {
+    const warnings: string[] = [];
+    const broken = PLAYBOOK_FIXTURE.replace("| Helpful    | 7          |", "| Helpful    | 7 (要確認) |");
+    const entries = parsePlaybookEntries(broken, (m) => warnings.push(m));
+    expect(entries.find((e) => e.id === "ACE-005")?.helpful).toBe(0);
+    expect(warnings.some((w) => w.includes("ACE-005") && w.includes("Helpful"))).toBe(true);
+  });
+
+  it("Status 欠落は警告して unknown に落とす", () => {
+    const warnings: string[] = [];
+    const broken = PLAYBOOK_FIXTURE.replace("| Status     | deprecated |", "");
+    const entries = parsePlaybookEntries(broken, (m) => warnings.push(m));
+    expect(entries.find((e) => e.id === "ACE-100")?.status).toBe("unknown");
+    expect(warnings.some((w) => w.includes("ACE-100") && w.includes("Status"))).toBe(true);
   });
 });
 
 describe("parseGitLog", () => {
   it("レコード区切り・フィールド区切りで日時/件名/本文に分解する", () => {
-    const commits = parseGitLog(gitLogFixture());
-    expect(commits).toHaveLength(4);
-    expect(commits[0]).toMatchObject({ date: "2026-07-01", subject: "fix: ACE-005 の教訓を適用" });
+    const result = parseGitLog(gitLogFixture());
+    expect(result.commits).toHaveLength(4);
+    expect(result.malformedCount).toBe(0);
+    expect(result.commits[0]).toMatchObject({ date: "2026-07-01", subject: "fix: ACE-005 の教訓を適用" });
+  });
+
+  it("date を持たない壊れたレコードは除外して malformedCount で報告する", () => {
+    const result = parseGitLog(`${RS}not-a-date${FS}subject${FS}body\n${gitLogFixture()}`);
+    expect(result.commits).toHaveLength(4);
+    expect(result.malformedCount).toBe(1);
   });
 });
 
 describe("computeReuseStats", () => {
-  const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
-  const commits = parseGitLog(gitLogFixture());
-  const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
+  const stats = statsFor(PLAYBOOK_FIXTURE, gitLogFixture());
 
   it("knowledge: コミットを除外して git 参照を数える（コミット単位で1カウント）", () => {
-    // ACE-005: 2026-07-01 の fix と 2026-04-01 の feat の 2 回（knowledge: は除外、同一コミット内の重複言及は1回）
     expect(stats.get("ACE-005")).toMatchObject({ gitRefCount: 2, lastGitRefDate: "2026-07-01" });
   });
 
-  it("キュレーションコミットしかないエントリの git 参照は 0", () => {
-    expect(stats.get("ACE-449-1")).toMatchObject({ gitRefCount: 0, lastGitRefDate: "" });
+  it("ACE-i 系 ID の参照も数える", () => {
+    expect(stats.get("ACE-i425-1")).toMatchObject({ gitRefCount: 1, lastGitRefDate: "2026-04-01" });
+  });
+
+  it("キュレーションコミットしかないエントリの git 参照は 0（lastGitRefDate は null）", () => {
+    expect(stats.get("ACE-449-1")).toMatchObject({ gitRefCount: 0, lastGitRefDate: null });
   });
 
   it("PLAYBOOK 内の相互参照を数える（自己参照は除外）", () => {
-    // ACE-449-1 の本文が ACE-005 を参照
     expect(stats.get("ACE-005")?.crossRefCount).toBe(1);
     expect(stats.get("ACE-449-1")?.crossRefCount).toBe(0);
   });
 });
 
 describe("findArchiveCandidates", () => {
-  const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
-  const commits = parseGitLog(gitLogFixture());
-  const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
-  const now = new Date("2026-10-01T00:00:00Z");
+  const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE, () => {});
+  const stats = statsFor(PLAYBOOK_FIXTURE, gitLogFixture());
   const STALE_DAYS = 90;
 
   it("作成から閾値経過 + git 参照なしのアクティブエントリを候補にする", () => {
-    // ACE-449-1: 2026-07-02 作成（91日前）・git 参照 0 → 候補
-    const candidates = findArchiveCandidates(entries, stats, now, STALE_DAYS);
+    // ACE-449-1: 2026-07-02 作成・git 参照 0 → 2026-10-01 時点（91日後）で候補
+    const candidates = findArchiveCandidates(entries, stats, new Date("2026-10-01T00:00:00Z"), STALE_DAYS);
     expect(candidates.map((e) => e.id)).toContain("ACE-449-1");
   });
 
+  it("境界値: 作成からちょうど staleDays 経過は候補になる（>= 判定）", () => {
+    // ACE-449-1 は 2026-07-02 作成 → 2026-09-30 でちょうど 90 日
+    const candidates = findArchiveCandidates(entries, stats, new Date("2026-09-30T00:00:00Z"), STALE_DAYS);
+    expect(candidates.map((e) => e.id)).toContain("ACE-449-1");
+  });
+
+  it("境界値: 最終参照からちょうど staleDays 経過は候補になる（>= 判定）", () => {
+    // ACE-005 の最終参照 2026-07-01 → 2026-09-29 でちょうど 90 日
+    const candidates = findArchiveCandidates(entries, stats, new Date("2026-09-29T00:00:00Z"), STALE_DAYS);
+    expect(candidates.map((e) => e.id)).toContain("ACE-005");
+  });
+
   it("最終参照が閾値以内のエントリは候補にしない", () => {
-    // ACE-005: 最終参照 2026-07-01（92日前）→ 閾値ちょうど超えで候補になる
-    // now を 2026-08-01 にすると 31 日前 → 候補外
     const recent = findArchiveCandidates(entries, stats, new Date("2026-08-01T00:00:00Z"), STALE_DAYS);
     expect(recent.map((e) => e.id)).not.toContain("ACE-005");
   });
 
   it("deprecated エントリは候補にしない", () => {
-    const candidates = findArchiveCandidates(entries, stats, now, STALE_DAYS);
+    const candidates = findArchiveCandidates(entries, stats, new Date("2026-10-01T00:00:00Z"), STALE_DAYS);
     expect(candidates.map((e) => e.id)).not.toContain("ACE-100");
   });
 
@@ -138,30 +196,87 @@ describe("findArchiveCandidates", () => {
     const young = findArchiveCandidates(entries, stats, new Date("2026-07-10T00:00:00Z"), STALE_DAYS);
     expect(young.map((e) => e.id)).not.toContain("ACE-449-1");
   });
+
+  it("参照実績があるのに日付が解釈不能なエントリは候補にしない（安全側）", () => {
+    const brokenStats = new Map<string, ReuseStats>([
+      ["ACE-005", { gitRefCount: 3, lastGitRefDate: "invalid-date", crossRefCount: 0 }],
+    ]);
+    const candidates = findArchiveCandidates(entries, brokenStats, new Date("2026-10-01T00:00:00Z"), STALE_DAYS);
+    expect(candidates.map((e) => e.id)).not.toContain("ACE-005");
+  });
 });
 
 describe("formatReport", () => {
-  it("参照合計の降順で表を出力し、Helpful との乖離を含む", () => {
-    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
-    const commits = parseGitLog(gitLogFixture());
-    const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
-    const now = new Date("2026-10-01T00:00:00Z");
-    const report = formatReport(entries, stats, [], now, 90);
+  it("参照合計の降順で表を出力し、乖離 =（git参照 + 相互参照）− Helpful を含む", () => {
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE, () => {});
+    const stats = statsFor(PLAYBOOK_FIXTURE, gitLogFixture());
+    const report = formatReport(entries, stats, [], new Date("2026-10-01T00:00:00Z"), 90);
 
     expect(report).toContain("# ACE 再利用計測レポート");
-    // ACE-005（git 2 + cross 1 = 3）が先頭
     const ace005Pos = report.indexOf("| ACE-005 |");
     const ace449Pos = report.indexOf("| ACE-449-1 |");
     expect(ace005Pos).toBeGreaterThan(-1);
-    expect(ace449Pos).toBeGreaterThan(ace005Pos * 0); // 存在確認
+    expect(ace449Pos).toBeGreaterThan(-1);
     expect(ace005Pos).toBeLessThan(ace449Pos);
-    // 乖離: ACE-005 は gitRef 2 - Helpful 7 = -5
-    expect(report).toContain("| ACE-005 | 2 | 2026-07-01 | 1 | 7 | -5 | active |");
+    // ACE-005: git 2 + cross 1 - Helpful 7 = -4
+    expect(report).toContain("| ACE-005 | 2 | 2026-07-01 | 1 | 7 | -4 | active |");
   });
 
   it("候補ゼロのときは「なし」と出力する", () => {
-    const report = formatReport([], new Map(), [], new Date("2026-10-01T00:00:00Z"), 90);
+    const report = formatReport([], new Map<string, ReuseStats>(), [], new Date("2026-10-01T00:00:00Z"), 90);
     expect(report).toContain("## Archive 候補（0 件）");
     expect(report).toContain("なし");
+  });
+});
+
+describe("main（CLI エントリポイント）", () => {
+  it("引数なしは usage を出して exit 2", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(main([])).toBe(2);
+    expect(errSpy.mock.calls.flat().join("\n")).toContain("Usage:");
+  });
+
+  it("存在しないファイルは exit 2", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(main(["/no/such/playbook.md"])).toBe(2);
+    expect(errSpy.mock.calls.flat().join("\n")).toContain("見つかりません");
+  });
+
+  it("正常系: 注入した git log でレポートを stdout に出力して exit 0", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ace-reuse-main-"));
+    const playbook = path.join(tmp, "PLAYBOOK.md");
+    fs.writeFileSync(playbook, PLAYBOOK_FIXTURE);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const code = main([playbook], {
+        readLog: () => parseGitLog(gitLogFixture()),
+        now: () => new Date("2026-10-01T00:00:00Z"),
+      });
+      expect(code).toBe(0);
+      const out = logSpy.mock.calls.flat().join("\n");
+      expect(out).toContain("# ACE 再利用計測レポート");
+      expect(out).toContain("| ACE-005 |");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("readLog が失敗したら整形エラーで exit 1（生 stack trace にしない）", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ace-reuse-err-"));
+    const playbook = path.join(tmp, "PLAYBOOK.md");
+    fs.writeFileSync(playbook, PLAYBOOK_FIXTURE);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const code = main([playbook], {
+        readLog: () => {
+          throw new Error("fatal: not a git repository (or any of the parent directories)");
+        },
+        now: () => new Date("2026-10-01T00:00:00Z"),
+      });
+      expect(code).toBe(1);
+      expect(errSpy.mock.calls.flat().join("\n")).toContain("git リポジトリ内にありません");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/docs-template/scripts/ace/ace-reuse-report.test.ts
+++ b/docs-template/scripts/ace/ace-reuse-report.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeReuseStats,
+  findArchiveCandidates,
+  formatReport,
+  parseGitLog,
+  parsePlaybookEntries,
+} from "./ace-reuse-report";
+
+const RS = "\x1e";
+const FS = "\x1f";
+
+const PLAYBOOK_FIXTURE = `
+# ACE Playbook
+
+<!-- 追記例:
+### ACE-001: コメント内の偽エントリ
+-->
+
+<a id="ace-005"></a>
+
+### ACE-005: 異なる AI モデルは異なるカテゴリの問題を検出
+
+| フィールド | 値         |
+| ---------- | ---------- |
+| Category   | process    |
+| Date       | 2026-03-15 |
+| Helpful    | 7          |
+| Status     | active     |
+
+本文。
+
+<a id="ace-449-1"></a>
+
+### ACE-449-1: set -e 関数末尾の &&-list
+
+| フィールド | 値         |
+| ---------- | ---------- |
+| Category   | tooling    |
+| Date       | 2026-07-02 |
+| Helpful    | 0          |
+| Status     | active     |
+
+[ACE-005](#ace-005) を参照する本文。
+
+<a id="ace-100"></a>
+
+### ACE-100: 廃止済みエントリ
+
+| フィールド | 値         |
+| ---------- | ---------- |
+| Category   | process    |
+| Date       | 2026-01-01 |
+| Helpful    | 2          |
+| Status     | deprecated |
+
+本文。
+`;
+
+function gitLogFixture(): string {
+  // 新しい順（git log と同じ）
+  return [
+    `${RS}2026-07-01${FS}fix: ACE-005 の教訓を適用${FS}本文で ACE-005 に再度言及`,
+    `${RS}2026-06-20${FS}knowledge: ACE-449-1 追加（キュレーション）${FS}ACE-449-1 と ACE-005 を含むが除外されるべき`,
+    `${RS}2026-04-01${FS}feat: 通常コミット${FS}ACE-005 参照`,
+    `${RS}2026-03-01${FS}docs: 無関係${FS}ACE-XXX プレースホルダは数えない`,
+  ].join("\n");
+}
+
+describe("parsePlaybookEntries", () => {
+  it("実エントリのみ抽出し、HTMLコメント内の偽エントリを除外する", () => {
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+    expect(entries.map((e) => e.id)).toEqual(["ACE-005", "ACE-449-1", "ACE-100"]);
+  });
+
+  it("Date / Helpful / Status をテーブルから読み取る", () => {
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+    const ace005 = entries.find((e) => e.id === "ACE-005");
+    expect(ace005).toMatchObject({ date: "2026-03-15", helpful: 7, status: "active" });
+  });
+});
+
+describe("parseGitLog", () => {
+  it("レコード区切り・フィールド区切りで日時/件名/本文に分解する", () => {
+    const commits = parseGitLog(gitLogFixture());
+    expect(commits).toHaveLength(4);
+    expect(commits[0]).toMatchObject({ date: "2026-07-01", subject: "fix: ACE-005 の教訓を適用" });
+  });
+});
+
+describe("computeReuseStats", () => {
+  const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+  const commits = parseGitLog(gitLogFixture());
+  const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
+
+  it("knowledge: コミットを除外して git 参照を数える（コミット単位で1カウント）", () => {
+    // ACE-005: 2026-07-01 の fix と 2026-04-01 の feat の 2 回（knowledge: は除外、同一コミット内の重複言及は1回）
+    expect(stats.get("ACE-005")).toMatchObject({ gitRefCount: 2, lastGitRefDate: "2026-07-01" });
+  });
+
+  it("キュレーションコミットしかないエントリの git 参照は 0", () => {
+    expect(stats.get("ACE-449-1")).toMatchObject({ gitRefCount: 0, lastGitRefDate: "" });
+  });
+
+  it("PLAYBOOK 内の相互参照を数える（自己参照は除外）", () => {
+    // ACE-449-1 の本文が ACE-005 を参照
+    expect(stats.get("ACE-005")?.crossRefCount).toBe(1);
+    expect(stats.get("ACE-449-1")?.crossRefCount).toBe(0);
+  });
+});
+
+describe("findArchiveCandidates", () => {
+  const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+  const commits = parseGitLog(gitLogFixture());
+  const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
+  const now = new Date("2026-10-01T00:00:00Z");
+  const STALE_DAYS = 90;
+
+  it("作成から閾値経過 + git 参照なしのアクティブエントリを候補にする", () => {
+    // ACE-449-1: 2026-07-02 作成（91日前）・git 参照 0 → 候補
+    const candidates = findArchiveCandidates(entries, stats, now, STALE_DAYS);
+    expect(candidates.map((e) => e.id)).toContain("ACE-449-1");
+  });
+
+  it("最終参照が閾値以内のエントリは候補にしない", () => {
+    // ACE-005: 最終参照 2026-07-01（92日前）→ 閾値ちょうど超えで候補になる
+    // now を 2026-08-01 にすると 31 日前 → 候補外
+    const recent = findArchiveCandidates(entries, stats, new Date("2026-08-01T00:00:00Z"), STALE_DAYS);
+    expect(recent.map((e) => e.id)).not.toContain("ACE-005");
+  });
+
+  it("deprecated エントリは候補にしない", () => {
+    const candidates = findArchiveCandidates(entries, stats, now, STALE_DAYS);
+    expect(candidates.map((e) => e.id)).not.toContain("ACE-100");
+  });
+
+  it("作成から閾値未満の若いエントリは参照ゼロでも候補にしない", () => {
+    const young = findArchiveCandidates(entries, stats, new Date("2026-07-10T00:00:00Z"), STALE_DAYS);
+    expect(young.map((e) => e.id)).not.toContain("ACE-449-1");
+  });
+});
+
+describe("formatReport", () => {
+  it("参照合計の降順で表を出力し、Helpful との乖離を含む", () => {
+    const entries = parsePlaybookEntries(PLAYBOOK_FIXTURE);
+    const commits = parseGitLog(gitLogFixture());
+    const stats = computeReuseStats(entries, commits, PLAYBOOK_FIXTURE);
+    const now = new Date("2026-10-01T00:00:00Z");
+    const report = formatReport(entries, stats, [], now, 90);
+
+    expect(report).toContain("# ACE 再利用計測レポート");
+    // ACE-005（git 2 + cross 1 = 3）が先頭
+    const ace005Pos = report.indexOf("| ACE-005 |");
+    const ace449Pos = report.indexOf("| ACE-449-1 |");
+    expect(ace005Pos).toBeGreaterThan(-1);
+    expect(ace449Pos).toBeGreaterThan(ace005Pos * 0); // 存在確認
+    expect(ace005Pos).toBeLessThan(ace449Pos);
+    // 乖離: ACE-005 は gitRef 2 - Helpful 7 = -5
+    expect(report).toContain("| ACE-005 | 2 | 2026-07-01 | 1 | 7 | -5 | active |");
+  });
+
+  it("候補ゼロのときは「なし」と出力する", () => {
+    const report = formatReport([], new Map(), [], new Date("2026-10-01T00:00:00Z"), 90);
+    expect(report).toContain("## Archive 候補（0 件）");
+    expect(report).toContain("なし");
+  });
+});

--- a/docs-template/scripts/ace/ace-reuse-report.ts
+++ b/docs-template/scripts/ace/ace-reuse-report.ts
@@ -6,14 +6,20 @@
  * - 長期間参照のないエントリを「Archive 候補」として列挙（Issue #455 の入力データ）
  *
  * 読み取り専用 — PLAYBOOK もリポジトリ履歴も変更しない。gh API 非依存（オフライン動作）。
+ * git log は PLAYBOOK が属するリポジトリ（`git -C <playbookのディレクトリ>`）に対して実行し、
+ * カレントディレクトリや hook 由来の GIT_DIR に影響されない。
  * 実行例: npx --yes tsx docs-template/scripts/ace/ace-reuse-report.ts docs-template/08-knowledge/PLAYBOOK.md
  */
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import { parsePositiveIntEnv } from "./check-category-size";
 
 const EXIT_OK = 0;
+const EXIT_RUNTIME_ERROR = 1;
 const EXIT_USAGE_ERROR = 2;
+
+const WARN_PREFIX = "ace-reuse-report";
 
 /** これより長く git 参照がないエントリを Archive 候補とする（日数、ACE_REUSE_STALE_DAYS で上書き可） */
 const DEFAULT_STALE_DAYS = 90;
@@ -34,11 +40,15 @@ const ENTRY_HEADER_PATTERN = /^### (ACE-(?:\d+(?:-\d+)?|i\d+(?:-\d+)?)): (.+)$/g
 /** キュレーションコミット（エントリ追加・カウンター更新）は「再利用」に数えない */
 const CURATION_COMMIT_PREFIX = "knowledge:";
 
+const STATUS_ACTIVE = "active";
+
 export type PlaybookEntry = Readonly<{
   readonly id: string;
   readonly title: string;
-  readonly date: string; // YYYY-MM-DD（不明時は ""）
+  /** YYYY-MM-DD。テーブル欠落・不正時は null */
+  readonly date: string | null;
   readonly helpful: number;
+  /** PLAYBOOK の Status 語彙は open（active / deprecated / 試行中 等）。欠落時は "unknown" */
   readonly status: string;
 }>;
 
@@ -48,9 +58,16 @@ export type GitCommitRecord = Readonly<{
   readonly body: string;
 }>;
 
+export type GitLogParseResult = Readonly<{
+  readonly commits: readonly GitCommitRecord[];
+  /** date を持たない壊れたレコード数（呼び出し側が警告する） */
+  readonly malformedCount: number;
+}>;
+
 export type ReuseStats = Readonly<{
   readonly gitRefCount: number;
-  readonly lastGitRefDate: string; // "" = 参照なし
+  /** null = git 参照なし */
+  readonly lastGitRefDate: string | null;
   readonly crossRefCount: number;
 }>;
 
@@ -58,52 +75,93 @@ function stripHtmlBlockComments(source: string): string {
   return source.replace(/<!--[\s\S]*?-->/gu, "");
 }
 
-function extractTableField(segment: string, field: string): string {
+function extractTableField(segment: string, field: string): string | null {
   const pattern = new RegExp(`^\\|\\s*${field}\\s*\\|\\s*([^|]+)\\|`, "im");
   const match = segment.match(pattern);
-  return match ? match[1].trim() : "";
+  return match ? match[1].trim() : null;
 }
 
 /**
  * PLAYBOOK.md からエントリ（ID / タイトル / Date / Helpful / Status）を抽出する。
- * HTML コメント内の追記例は除外する。
+ * HTML コメント内の追記例は除外する。フィールドが「存在するが不正」な場合は
+ * onWarn（既定: console.warn）で表面化させたうえで安全なデフォルトに落とす。
  */
-export function parsePlaybookEntries(content: string): PlaybookEntry[] {
+export function parsePlaybookEntries(
+  content: string,
+  onWarn: (message: string) => void = (m) => console.warn(m),
+): PlaybookEntry[] {
   const cleaned = stripHtmlBlockComments(content);
   const entries: PlaybookEntry[] = [];
   const headers = [...cleaned.matchAll(ENTRY_HEADER_PATTERN)];
 
   headers.forEach((match, index) => {
+    const id = match[1];
     const start = (match.index ?? 0) + match[0].length;
     const end =
       index + 1 < headers.length ? (headers[index + 1].index ?? cleaned.length) : cleaned.length;
     const segment = cleaned.slice(start, end);
 
     const helpfulRaw = extractTableField(segment, "Helpful");
-    const helpful = /^\d+$/u.test(helpfulRaw) ? Number.parseInt(helpfulRaw, 10) : 0;
+    let helpful = 0;
+    if (helpfulRaw === null) {
+      onWarn(`${WARN_PREFIX}: ${id} の Helpful フィールドが見つかりません（0 として扱います）`);
+    } else if (/^\d+$/u.test(helpfulRaw)) {
+      helpful = Number.parseInt(helpfulRaw, 10);
+    } else {
+      onWarn(
+        `${WARN_PREFIX}: ${id} の Helpful "${helpfulRaw}" は数値ではありません（0 として扱います）`,
+      );
+    }
+
+    const status = extractTableField(segment, "Status");
+    if (status === null) {
+      onWarn(`${WARN_PREFIX}: ${id} の Status フィールドが見つかりません（unknown として扱います）`);
+    }
+
+    const dateRaw = extractTableField(segment, "Date");
+    const date = dateRaw && /^\d{4}-\d{2}-\d{2}$/u.test(dateRaw) ? dateRaw : null;
+    if (dateRaw !== null && date === null) {
+      onWarn(`${WARN_PREFIX}: ${id} の Date "${dateRaw}" は YYYY-MM-DD ではありません（不明として扱います）`);
+    }
 
     entries.push({
-      id: match[1],
+      id,
       title: match[2].trim(),
-      date: extractTableField(segment, "Date"),
+      date,
       helpful,
-      status: extractTableField(segment, "Status") || "unknown",
+      status: status ?? "unknown",
     });
   });
 
   return entries;
 }
 
-/** `git log` の RECORD/FIELD 区切り出力をパースする */
-export function parseGitLog(raw: string): GitCommitRecord[] {
-  return raw
-    .split(RECORD_SEPARATOR)
-    .map((record) => record.trim())
-    .filter((record) => record.length > 0)
-    .map((record) => {
-      const [date = "", subject = "", ...bodyParts] = record.split(FIELD_SEPARATOR);
-      return { date: date.trim(), subject: subject.trim(), body: bodyParts.join(FIELD_SEPARATOR) };
+/**
+ * `git log` の RECORD/FIELD 区切り出力をパースする。
+ * date を持たない壊れたレコードは commits に含めず malformedCount で報告する。
+ */
+export function parseGitLog(raw: string): GitLogParseResult {
+  const commits: GitCommitRecord[] = [];
+  let malformedCount = 0;
+
+  for (const record of raw.split(RECORD_SEPARATOR)) {
+    const trimmed = record.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const [date = "", subject = "", ...bodyParts] = trimmed.split(FIELD_SEPARATOR);
+    if (!/^\d{4}-\d{2}-\d{2}$/u.test(date.trim())) {
+      malformedCount += 1;
+      continue;
+    }
+    commits.push({
+      date: date.trim(),
+      subject: subject.trim(),
+      body: bodyParts.join(FIELD_SEPARATOR),
     });
+  }
+
+  return { commits, malformedCount };
 }
 
 /**
@@ -161,14 +219,17 @@ export function computeReuseStats(
   for (const entry of entries) {
     stats.set(entry.id, {
       gitRefCount: gitRefCount.get(entry.id) ?? 0,
-      lastGitRefDate: lastGitRefDate.get(entry.id) ?? "",
+      lastGitRefDate: lastGitRefDate.get(entry.id) ?? null,
       crossRefCount: crossRefCount.get(entry.id) ?? 0,
     });
   }
   return stats;
 }
 
-function daysBetween(fromIso: string, to: Date): number | null {
+function daysBetween(fromIso: string | null, to: Date): number | null {
+  if (fromIso === null) {
+    return null;
+  }
   const from = new Date(`${fromIso}T00:00:00Z`);
   if (Number.isNaN(from.getTime())) {
     return null;
@@ -179,6 +240,7 @@ function daysBetween(fromIso: string, to: Date): number | null {
 /**
  * Archive 候補 = Status が active、作成から staleDays 以上経過、
  * かつ git 参照が一度もない or 最終 git 参照が staleDays 以上前。
+ * 判定不能なデータ（日付欠損・stats 欠落）は**候補にしない**（安全側 = 誤アーカイブ推奨を避ける）。
  * （判定は「候補の列挙」のみ。実際のアーカイブは Issue #455 で別途設計）
  */
 export function findArchiveCandidates(
@@ -188,7 +250,7 @@ export function findArchiveCandidates(
   staleDays: number,
 ): PlaybookEntry[] {
   return entries.filter((entry) => {
-    if (entry.status !== "active") {
+    if (entry.status !== STATUS_ACTIVE) {
       return false;
     }
     const ageDays = daysBetween(entry.date, now);
@@ -197,17 +259,20 @@ export function findArchiveCandidates(
     }
     const stat = stats.get(entry.id);
     if (!stat) {
-      return true;
+      return false; // 判定材料なし → 安全側（候補にしない）
     }
     if (stat.gitRefCount === 0) {
       return true;
     }
     const sinceLastRef = daysBetween(stat.lastGitRefDate, now);
-    return sinceLastRef === null || sinceLastRef >= staleDays;
+    if (sinceLastRef === null) {
+      return false; // 参照実績はあるが日付が解釈不能 → 安全側（候補にしない）
+    }
+    return sinceLastRef >= staleDays;
   });
 }
 
-/** Markdown レポートを組み立てる */
+/** Markdown レポートを組み立てる。乖離 =（git参照 + 相互参照）− Helpful */
 export function formatReport(
   entries: readonly PlaybookEntry[],
   stats: ReadonlyMap<string, ReuseStats>,
@@ -215,13 +280,11 @@ export function formatReport(
   now: Date,
   staleDays: number,
 ): string {
-  const sorted = [...entries].sort((a, b) => {
-    const sa = stats.get(a.id);
-    const sb = stats.get(b.id);
-    return (
-      (sb?.gitRefCount ?? 0) + (sb?.crossRefCount ?? 0) - ((sa?.gitRefCount ?? 0) + (sa?.crossRefCount ?? 0))
-    );
-  });
+  const totalRefs = (id: string): number => {
+    const stat = stats.get(id);
+    return (stat?.gitRefCount ?? 0) + (stat?.crossRefCount ?? 0);
+  };
+  const sorted = [...entries].sort((a, b) => totalRefs(b.id) - totalRefs(a.id));
 
   const lines: string[] = [];
   lines.push(`# ACE 再利用計測レポート`);
@@ -235,9 +298,10 @@ export function formatReport(
   for (const entry of sorted) {
     const stat = stats.get(entry.id);
     const gitRefs = stat?.gitRefCount ?? 0;
-    const divergence = gitRefs - entry.helpful;
+    const crossRefs = stat?.crossRefCount ?? 0;
+    const divergence = gitRefs + crossRefs - entry.helpful;
     lines.push(
-      `| ${entry.id} | ${gitRefs} | ${stat?.lastGitRefDate || "—"} | ${stat?.crossRefCount ?? 0} | ${entry.helpful} | ${divergence >= 0 ? "+" : ""}${divergence} | ${entry.status} |`,
+      `| ${entry.id} | ${gitRefs} | ${stat?.lastGitRefDate ?? "—"} | ${crossRefs} | ${entry.helpful} | ${divergence >= 0 ? "+" : ""}${divergence} | ${entry.status} |`,
     );
   }
   lines.push("");
@@ -247,7 +311,9 @@ export function formatReport(
     lines.push("なし");
   } else {
     for (const entry of candidates) {
-      lines.push(`- ${entry.id}: ${entry.title}（Date: ${entry.date || "不明"} / Helpful: ${entry.helpful}）`);
+      lines.push(
+        `- ${entry.id}: ${entry.title}（Date: ${entry.date ?? "不明"} / Helpful: ${entry.helpful}）`,
+      );
     }
     lines.push("");
     lines.push(
@@ -258,16 +324,50 @@ export function formatReport(
   return lines.join("\n");
 }
 
-function readGitLog(): GitCommitRecord[] {
+/**
+ * PLAYBOOK が属するリポジトリの git log を取得する。
+ * - `git -C <repoDir>` で実行先を固定（カレントディレクトリ非依存）
+ * - GIT_* 環境変数を除去（git hook 経由の実行で GIT_DIR を継承すると別リポジトリを集計する）
+ */
+function readGitLog(repoDir: string): GitLogParseResult {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith("GIT_")) {
+      env[key] = value;
+    }
+  }
   const raw = execFileSync(
     "git",
-    ["log", "--date=short", `--pretty=format:${RECORD_SEPARATOR}%ad${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b`],
-    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    [
+      "-C",
+      repoDir,
+      "log",
+      "--date=short",
+      `--pretty=format:${RECORD_SEPARATOR}%ad${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b`,
+    ],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env },
   );
   return parseGitLog(raw);
 }
 
-export function main(argv: readonly string[] = process.argv.slice(2)): number {
+export type MainDeps = Readonly<{
+  readonly readLog: (repoDir: string) => GitLogParseResult;
+  readonly now: () => Date;
+}>;
+
+const DEFAULT_DEPS: MainDeps = {
+  readLog: readGitLog,
+  now: () => new Date(),
+};
+
+/**
+ * CLI エントリポイント。
+ * 引数: argv[0] = PLAYBOOK.md へのパス（必須）
+ * 出力: stdout に Markdown レポート、警告は stderr
+ * 終了コード: 0 = 成功 / 1 = 実行時エラー（git 失敗・読み込み失敗）/ 2 = 使用方法エラー
+ * deps はテスト用の注入ポイント（既定は実 git log と現在時刻）。
+ */
+export function main(argv: readonly string[] = process.argv.slice(2), deps: MainDeps = DEFAULT_DEPS): number {
   const playbookPath = argv[0];
   if (!playbookPath) {
     console.error(
@@ -275,8 +375,8 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     );
     return EXIT_USAGE_ERROR;
   }
-  if (!fs.existsSync(playbookPath)) {
-    console.error(`ERROR: PLAYBOOK が見つかりません: ${playbookPath}`);
+  if (!fs.existsSync(playbookPath) || !fs.statSync(playbookPath).isFile()) {
+    console.error(`ERROR: PLAYBOOK ファイルが見つかりません: ${playbookPath}`);
     return EXIT_USAGE_ERROR;
   }
 
@@ -284,21 +384,40 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     process.env.ACE_REUSE_STALE_DAYS,
     DEFAULT_STALE_DAYS,
     "ACE_REUSE_STALE_DAYS",
+    WARN_PREFIX,
   );
 
-  const content = fs.readFileSync(playbookPath, "utf8");
-  const entries = parsePlaybookEntries(content);
-  const commits = readGitLog();
-  const stats = computeReuseStats(entries, commits, content);
-  const now = new Date();
-  const candidates = findArchiveCandidates(entries, stats, now, staleDays);
-
-  console.log(formatReport(entries, stats, candidates, now, staleDays));
-  return EXIT_OK;
+  try {
+    const content = fs.readFileSync(playbookPath, "utf8");
+    const entries = parsePlaybookEntries(content);
+    const logResult = deps.readLog(path.dirname(path.resolve(playbookPath)));
+    if (logResult.malformedCount > 0) {
+      console.warn(
+        `${WARN_PREFIX}: git log に解釈できないレコードが ${logResult.malformedCount} 件ありました（集計から除外）`,
+      );
+    }
+    const stats = computeReuseStats(entries, logResult.commits, content);
+    const now = deps.now();
+    const candidates = findArchiveCandidates(entries, stats, now, staleDays);
+    console.log(formatReport(entries, stats, candidates, now, staleDays));
+    return EXIT_OK;
+  } catch (error) {
+    const err = error as { code?: string; message?: string };
+    if (err.code === "ENOENT") {
+      console.error(`ERROR: git コマンドが見つかりません（git をインストールしてください）`);
+    } else if (typeof err.message === "string" && /not a git repository/iu.test(err.message)) {
+      console.error(
+        `ERROR: PLAYBOOK が git リポジトリ内にありません（git log を取得できないため集計不能です）`,
+      );
+    } else {
+      console.error(`ERROR: レポート生成に失敗しました: ${err.message ?? String(error)}`);
+    }
+    return EXIT_RUNTIME_ERROR;
+  }
 }
 
 // 直接実行（tsx 経由の CLI）のときのみ自動実行する。テストから import した
 // ときは副作用なく関数だけを取り込めるようにする。
-if ((process.argv[1] ?? "").includes("ace-reuse-report")) {
+if ((process.argv[1] ?? "").includes("ace-reuse-report") && !(process.argv[1] ?? "").includes(".test.")) {
   process.exitCode = main();
 }

--- a/docs-template/scripts/ace/ace-reuse-report.ts
+++ b/docs-template/scripts/ace/ace-reuse-report.ts
@@ -1,0 +1,304 @@
+/**
+ * ACE 知見の再利用計測レポート（Issue #453）。
+ * - git log（`knowledge:` キュレーションコミットを除く）から各 ACE エントリへの参照を集計
+ * - PLAYBOOK.md 内のエントリ間相互参照（Related / 本文リンク）を集計
+ * - エントリごとに参照回数 / 最終参照日 / Helpful カウンターとの乖離を Markdown 表で出力
+ * - 長期間参照のないエントリを「Archive 候補」として列挙（Issue #455 の入力データ）
+ *
+ * 読み取り専用 — PLAYBOOK もリポジトリ履歴も変更しない。gh API 非依存（オフライン動作）。
+ * 実行例: npx --yes tsx docs-template/scripts/ace/ace-reuse-report.ts docs-template/08-knowledge/PLAYBOOK.md
+ */
+import * as fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import { parsePositiveIntEnv } from "./check-category-size";
+
+const EXIT_OK = 0;
+const EXIT_USAGE_ERROR = 2;
+
+/** これより長く git 参照がないエントリを Archive 候補とする（日数、ACE_REUSE_STALE_DAYS で上書き可） */
+const DEFAULT_STALE_DAYS = 90;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** git log のレコード / フィールド区切り（コミット本文に現れない制御文字） */
+const RECORD_SEPARATOR = "\x1e";
+const FIELD_SEPARATOR = "\x1f";
+
+/**
+ * 実 ID のみマッチ（旧 3 桁 ACE-001 / PRスコープ ACE-438-1 / Issue 由来 ACE-i425-1）。
+ * テンプレートのプレースホルダ（ACE-XXX 等）は数字始まりでないため除外される。
+ */
+const ACE_ID_REFERENCE_PATTERN = /\bACE-(?:\d+(?:-\d+)?|i\d+(?:-\d+)?)\b/gu;
+
+const ENTRY_HEADER_PATTERN = /^### (ACE-(?:\d+(?:-\d+)?|i\d+(?:-\d+)?)): (.+)$/gmu;
+
+/** キュレーションコミット（エントリ追加・カウンター更新）は「再利用」に数えない */
+const CURATION_COMMIT_PREFIX = "knowledge:";
+
+export type PlaybookEntry = Readonly<{
+  readonly id: string;
+  readonly title: string;
+  readonly date: string; // YYYY-MM-DD（不明時は ""）
+  readonly helpful: number;
+  readonly status: string;
+}>;
+
+export type GitCommitRecord = Readonly<{
+  readonly date: string; // YYYY-MM-DD
+  readonly subject: string;
+  readonly body: string;
+}>;
+
+export type ReuseStats = Readonly<{
+  readonly gitRefCount: number;
+  readonly lastGitRefDate: string; // "" = 参照なし
+  readonly crossRefCount: number;
+}>;
+
+function stripHtmlBlockComments(source: string): string {
+  return source.replace(/<!--[\s\S]*?-->/gu, "");
+}
+
+function extractTableField(segment: string, field: string): string {
+  const pattern = new RegExp(`^\\|\\s*${field}\\s*\\|\\s*([^|]+)\\|`, "im");
+  const match = segment.match(pattern);
+  return match ? match[1].trim() : "";
+}
+
+/**
+ * PLAYBOOK.md からエントリ（ID / タイトル / Date / Helpful / Status）を抽出する。
+ * HTML コメント内の追記例は除外する。
+ */
+export function parsePlaybookEntries(content: string): PlaybookEntry[] {
+  const cleaned = stripHtmlBlockComments(content);
+  const entries: PlaybookEntry[] = [];
+  const headers = [...cleaned.matchAll(ENTRY_HEADER_PATTERN)];
+
+  headers.forEach((match, index) => {
+    const start = (match.index ?? 0) + match[0].length;
+    const end =
+      index + 1 < headers.length ? (headers[index + 1].index ?? cleaned.length) : cleaned.length;
+    const segment = cleaned.slice(start, end);
+
+    const helpfulRaw = extractTableField(segment, "Helpful");
+    const helpful = /^\d+$/u.test(helpfulRaw) ? Number.parseInt(helpfulRaw, 10) : 0;
+
+    entries.push({
+      id: match[1],
+      title: match[2].trim(),
+      date: extractTableField(segment, "Date"),
+      helpful,
+      status: extractTableField(segment, "Status") || "unknown",
+    });
+  });
+
+  return entries;
+}
+
+/** `git log` の RECORD/FIELD 区切り出力をパースする */
+export function parseGitLog(raw: string): GitCommitRecord[] {
+  return raw
+    .split(RECORD_SEPARATOR)
+    .map((record) => record.trim())
+    .filter((record) => record.length > 0)
+    .map((record) => {
+      const [date = "", subject = "", ...bodyParts] = record.split(FIELD_SEPARATOR);
+      return { date: date.trim(), subject: subject.trim(), body: bodyParts.join(FIELD_SEPARATOR) };
+    });
+}
+
+/**
+ * エントリごとの再利用実績を集計する。
+ * - git 参照: `knowledge:` コミットを除くコミットの件名 + 本文中の ACE ID 出現（コミット単位で 1 カウント）
+ * - 相互参照: PLAYBOOK 内で「他の」エントリのセグメントに現れる ACE ID 出現
+ */
+export function computeReuseStats(
+  entries: readonly PlaybookEntry[],
+  commits: readonly GitCommitRecord[],
+  playbookContent: string,
+): Map<string, ReuseStats> {
+  const knownIds = new Set(entries.map((entry) => entry.id));
+  const gitRefCount = new Map<string, number>();
+  const lastGitRefDate = new Map<string, string>();
+
+  for (const commit of commits) {
+    if (commit.subject.startsWith(CURATION_COMMIT_PREFIX)) {
+      continue;
+    }
+    const text = `${commit.subject}\n${commit.body}`;
+    const idsInCommit = new Set(
+      [...text.matchAll(ACE_ID_REFERENCE_PATTERN)].map((m) => m[0]).filter((id) => knownIds.has(id)),
+    );
+    for (const id of idsInCommit) {
+      gitRefCount.set(id, (gitRefCount.get(id) ?? 0) + 1);
+      // git log は新しい順なので、最初に見つかった日付が最終参照日
+      if (!lastGitRefDate.has(id)) {
+        lastGitRefDate.set(id, commit.date);
+      }
+    }
+  }
+
+  // 相互参照: 各エントリのセグメント内に現れる他エントリの ID
+  const crossRefCount = new Map<string, number>();
+  const cleaned = stripHtmlBlockComments(playbookContent);
+  const headers = [...cleaned.matchAll(ENTRY_HEADER_PATTERN)];
+  headers.forEach((match, index) => {
+    const ownerId = match[1];
+    const start = (match.index ?? 0) + match[0].length;
+    const end =
+      index + 1 < headers.length ? (headers[index + 1].index ?? cleaned.length) : cleaned.length;
+    const segment = cleaned.slice(start, end);
+    const referenced = new Set(
+      [...segment.matchAll(ACE_ID_REFERENCE_PATTERN)]
+        .map((m) => m[0])
+        .filter((id) => id !== ownerId && knownIds.has(id)),
+    );
+    for (const id of referenced) {
+      crossRefCount.set(id, (crossRefCount.get(id) ?? 0) + 1);
+    }
+  });
+
+  const stats = new Map<string, ReuseStats>();
+  for (const entry of entries) {
+    stats.set(entry.id, {
+      gitRefCount: gitRefCount.get(entry.id) ?? 0,
+      lastGitRefDate: lastGitRefDate.get(entry.id) ?? "",
+      crossRefCount: crossRefCount.get(entry.id) ?? 0,
+    });
+  }
+  return stats;
+}
+
+function daysBetween(fromIso: string, to: Date): number | null {
+  const from = new Date(`${fromIso}T00:00:00Z`);
+  if (Number.isNaN(from.getTime())) {
+    return null;
+  }
+  return Math.floor((to.getTime() - from.getTime()) / MS_PER_DAY);
+}
+
+/**
+ * Archive 候補 = Status が active、作成から staleDays 以上経過、
+ * かつ git 参照が一度もない or 最終 git 参照が staleDays 以上前。
+ * （判定は「候補の列挙」のみ。実際のアーカイブは Issue #455 で別途設計）
+ */
+export function findArchiveCandidates(
+  entries: readonly PlaybookEntry[],
+  stats: ReadonlyMap<string, ReuseStats>,
+  now: Date,
+  staleDays: number,
+): PlaybookEntry[] {
+  return entries.filter((entry) => {
+    if (entry.status !== "active") {
+      return false;
+    }
+    const ageDays = daysBetween(entry.date, now);
+    if (ageDays === null || ageDays < staleDays) {
+      return false;
+    }
+    const stat = stats.get(entry.id);
+    if (!stat) {
+      return true;
+    }
+    if (stat.gitRefCount === 0) {
+      return true;
+    }
+    const sinceLastRef = daysBetween(stat.lastGitRefDate, now);
+    return sinceLastRef === null || sinceLastRef >= staleDays;
+  });
+}
+
+/** Markdown レポートを組み立てる */
+export function formatReport(
+  entries: readonly PlaybookEntry[],
+  stats: ReadonlyMap<string, ReuseStats>,
+  candidates: readonly PlaybookEntry[],
+  now: Date,
+  staleDays: number,
+): string {
+  const sorted = [...entries].sort((a, b) => {
+    const sa = stats.get(a.id);
+    const sb = stats.get(b.id);
+    return (
+      (sb?.gitRefCount ?? 0) + (sb?.crossRefCount ?? 0) - ((sa?.gitRefCount ?? 0) + (sa?.crossRefCount ?? 0))
+    );
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ACE 再利用計測レポート`);
+  lines.push("");
+  lines.push(`- 実行日: ${now.toISOString().slice(0, 10)}`);
+  lines.push(`- エントリ数: ${entries.length}`);
+  lines.push(`- Archive 候補閾値: ${staleDays} 日（ACE_REUSE_STALE_DAYS で上書き可）`);
+  lines.push("");
+  lines.push("| ID | git参照 | 最終参照日 | 相互参照 | Helpful | 乖離 | Status |");
+  lines.push("| --- | ---: | --- | ---: | ---: | ---: | --- |");
+  for (const entry of sorted) {
+    const stat = stats.get(entry.id);
+    const gitRefs = stat?.gitRefCount ?? 0;
+    const divergence = gitRefs - entry.helpful;
+    lines.push(
+      `| ${entry.id} | ${gitRefs} | ${stat?.lastGitRefDate || "—"} | ${stat?.crossRefCount ?? 0} | ${entry.helpful} | ${divergence >= 0 ? "+" : ""}${divergence} | ${entry.status} |`,
+    );
+  }
+  lines.push("");
+  lines.push(`## Archive 候補（${candidates.length} 件）`);
+  lines.push("");
+  if (candidates.length === 0) {
+    lines.push("なし");
+  } else {
+    for (const entry of candidates) {
+      lines.push(`- ${entry.id}: ${entry.title}（Date: ${entry.date || "不明"} / Helpful: ${entry.helpful}）`);
+    }
+    lines.push("");
+    lines.push(
+      "> 候補は機械判定です。アーカイブの実施基準・手順は Issue #455 で設計します（本レポートは読み取り専用）。",
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function readGitLog(): GitCommitRecord[] {
+  const raw = execFileSync(
+    "git",
+    ["log", "--date=short", `--pretty=format:${RECORD_SEPARATOR}%ad${FIELD_SEPARATOR}%s${FIELD_SEPARATOR}%b`],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  return parseGitLog(raw);
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+  const playbookPath = argv[0];
+  if (!playbookPath) {
+    console.error(
+      "Usage: npx --yes tsx docs-template/scripts/ace/ace-reuse-report.ts <path/to/PLAYBOOK.md>",
+    );
+    return EXIT_USAGE_ERROR;
+  }
+  if (!fs.existsSync(playbookPath)) {
+    console.error(`ERROR: PLAYBOOK が見つかりません: ${playbookPath}`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const staleDays = parsePositiveIntEnv(
+    process.env.ACE_REUSE_STALE_DAYS,
+    DEFAULT_STALE_DAYS,
+    "ACE_REUSE_STALE_DAYS",
+  );
+
+  const content = fs.readFileSync(playbookPath, "utf8");
+  const entries = parsePlaybookEntries(content);
+  const commits = readGitLog();
+  const stats = computeReuseStats(entries, commits, content);
+  const now = new Date();
+  const candidates = findArchiveCandidates(entries, stats, now, staleDays);
+
+  console.log(formatReport(entries, stats, candidates, now, staleDays));
+  return EXIT_OK;
+}
+
+// 直接実行（tsx 経由の CLI）のときのみ自動実行する。テストから import した
+// ときは副作用なく関数だけを取り込めるようにする。
+if ((process.argv[1] ?? "").includes("ace-reuse-report")) {
+  process.exitCode = main();
+}

--- a/docs-template/scripts/ace/check-category-size.ts
+++ b/docs-template/scripts/ace/check-category-size.ts
@@ -107,11 +107,13 @@ export function analyzePlaybookMarkdown(content: string): AnalyzeResult {
  * 正の整数を表す環境変数を厳密に解釈する。`"800abc"` や `"1e3"` のような
  * 曖昧な値・0 以下・空値は無効として既定値にフォールバックし、stderr に警告を出す。
  * rawValue を引数で受け取り、副作用なくユニットテストできるようにしている。
+ * warnPrefix は警告の発信元スクリプト名（他スクリプトから再利用する際に上書きする）。
  */
 export function parsePositiveIntEnv(
   rawValue: string | undefined,
   defaultValue: number,
   envName: string,
+  warnPrefix: string = "ace-check",
 ): number {
   if (rawValue === undefined || rawValue.trim() === "") {
     return defaultValue;
@@ -119,7 +121,7 @@ export function parsePositiveIntEnv(
   const trimmed = rawValue.trim();
   if (!/^[0-9]+$/u.test(trimmed) || Number.parseInt(trimmed, 10) < 1) {
     console.warn(
-      `ace-check: ${envName}="${trimmed}" は無効のため、既定値 ${String(defaultValue)} を使います。`,
+      `${warnPrefix}: ${envName}="${trimmed}" は無効のため、既定値 ${String(defaultValue)} を使います。`,
     );
     return defaultValue;
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ace-scripts": "vitest run",
     "quality:local": "npm run build:mcp && npm run check && npm --prefix mcp test && npm run test:ace-scripts && npm run validate -- docs-template && npm run build:spec-index && npm run format:md:check && npm run lint:md",
     "ace:check-playbook-categories": "npx --yes tsx docs-template/scripts/ace/check-category-size.ts docs-template/08-knowledge/PLAYBOOK.md",
+    "ace:reuse-report": "npx --yes tsx docs-template/scripts/ace/ace-reuse-report.ts docs-template/08-knowledge/PLAYBOOK.md",
     "setup:labels": "bash scripts/setup-github-labels.sh",
     "prepare": "husky"
   },

--- a/scripts/review-scripts.test.ts
+++ b/scripts/review-scripts.test.ts
@@ -69,13 +69,30 @@ function makeStubDir(verdict: "PASS" | "FAIL"): string {
   return dir;
 }
 
+/**
+ * フィクスチャ用の git 環境。ユーザーのグローバル設定（gpgsign / hooksPath 等）を遮断し、
+ * さらに GIT_* 変数をすべて除去する — git hook（pre-push 等）経由でテストが実行されると
+ * git が GIT_DIR 等を設定するため、これを継承するとフィクスチャの git init/commit が
+ * 呼び出し元リポジトリを指してサイレントに失敗する（linked worktree からの push で実際に発生）。
+ */
+function sanitizedGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && !key.startsWith("GIT_")) {
+      env[key] = value;
+    }
+  }
+  env.GIT_CONFIG_GLOBAL = "/dev/null";
+  env.GIT_CONFIG_SYSTEM = "/dev/null";
+  return env;
+}
+
 function initGitRepo(dir: string): (...args: string[]) => void {
   const git = (...args: string[]) => {
     const r = spawnSync("git", args, {
       cwd: dir,
       encoding: "utf8",
-      // ユーザーのグローバル設定（gpgsign / hooksPath 等）を遮断して決定論化
-      env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+      env: sanitizedGitEnv(),
     });
     if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
   };


### PR DESCRIPTION
Closes #453

## 概要

ワークフロー多角的評価（PR #449 後）で指摘された「ACE 知見が書かれるだけで、効いているかの計測がない」問題への対応です。`npm run ace:reuse-report` で、PLAYBOOK 全エントリの再利用実績を客観データとして出力します。

## 出力内容

- **git参照**: `knowledge:` キュレーションコミットを除くコミット（件名+本文）での ACE ID 言及数・最終参照日
- **相互参照**: PLAYBOOK 内で他エントリから参照されている数
- **乖離**: git参照 − Helpful カウンター（手動更新との差分を可視化）
- **Archive 候補**: 作成から 90 日（`ACE_REUSE_STALE_DAYS` で上書き可）以上経過し、git 参照が閾値以内にない active エントリの列挙（Issue #455 の入力データ。読み取り専用で PLAYBOOK は変更しない）

## 実証

初回実行で **PLAYBOOK の実データバグを即検出**: 「異なる AI モデル」知見の実体は ACE-001（Helpful 7）なのに、Changelog 1.27.0 と ACE-445-1 の Related が ACE-005（別知見・Helpful 0）と誤記 → Issue #458 に分離。

## 付随修正（いずれも本PR作業中に実際に踏んだ穴）

1. **scripts/review-scripts.test.ts（PR #456 のファイル）**: git hook 経由で vitest が実行されると、git が設定する `GIT_DIR` をテストフィクスチャの git init/commit が継承し、**実リポジトリにフィクスチャコミットが混入**する欠陥を修正（`sanitizedGitEnv()` で GIT_* を除去）。linked worktree からの push が全ブロックされるため本PRに同梱
2. **.gitignore**: `node_modules/`（末尾スラッシュ）はディレクトリのみ対象で symlink を無視しないため、`node_modules` に変更

## テスト

- ace-reuse-report.test.ts（12件）: エントリパース、git log パース、knowledge: 除外集計、相互参照、Archive 候補の境界値、レポート整形
- 本PRの push 自体が pre-push フルゲート（84テスト）を通過済み。GIT_DIR 設定下（hook 環境模擬）での回帰も手元確認済み

## PR Size Check

- [x] ⚠️ 201〜400 行（スクリプト+テストが大半）

🤖 Generated with [Claude Code](https://claude.com/claude-code)