### PR TITLE
fix: #457 #461 生成物除外フィルタをサブディレクトリ対応 + pre-push を削除push時スキップ

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,15 +9,19 @@ fi
 
 # ブランチ削除 push（local sha が全ゼロ）だけならコード変更がないのでゲート不要（Issue #461）。
 # git は pre-push の stdin に "<local ref> <local sha> <remote ref> <remote sha>" を各 ref 分渡す。
-# stdin が空（端末での手動実行・テスト）の場合は saw_ref が false のままゲートへ進む。
+# 端末での手動実行は stdin が tty のため [ ! -t 0 ] が偽 → このブロックを飛ばしてゲートへ進む。
+# テスト等で stdin が空パイプの場合はブロックに入るが saw_ref が false のままゲートへ進む。
 if [ ! -t 0 ]; then
   saw_ref=false
   deletions_only=true
   while read -r _local_ref local_sha _remote_ref _remote_sha; do
     saw_ref=true
-    # 全ゼロ sha = 削除。非ゼロ文字を含めば通常の push（SHA-1/SHA-256 の桁数差にも耐える）
+    # 全ゼロ sha のみ = 削除。空（フィールド欠落）や非ゼロを含む = 想定外/通常 push は
+    # ゲート実行側に倒す（fail-closed。SHA-1/SHA-256 の桁数差にも耐える）
     case "$local_sha" in
-      *[!0]*) deletions_only=false ;;
+      "") deletions_only=false ;;      # フィールド欠落 = 想定外 → ゲート実行
+      *[!0]*) deletions_only=false ;;  # 非ゼロを含む = 通常 push → ゲート実行
+      *) : ;;                          # 全ゼロのみ = 削除（deletions_only を維持）
     esac
   done
   if [ "$saw_ref" = true ] && [ "$deletions_only" = true ]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,6 +7,25 @@ if [ "$SKIP_QUALITY_GATE" = "1" ]; then
   exit 0
 fi
 
+# ブランチ削除 push（local sha が全ゼロ）だけならコード変更がないのでゲート不要（Issue #461）。
+# git は pre-push の stdin に "<local ref> <local sha> <remote ref> <remote sha>" を各 ref 分渡す。
+# stdin が空（端末での手動実行・テスト）の場合は saw_ref が false のままゲートへ進む。
+if [ ! -t 0 ]; then
+  saw_ref=false
+  deletions_only=true
+  while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    saw_ref=true
+    # 全ゼロ sha = 削除。非ゼロ文字を含めば通常の push（SHA-1/SHA-256 の桁数差にも耐える）
+    case "$local_sha" in
+      *[!0]*) deletions_only=false ;;
+    esac
+  done
+  if [ "$saw_ref" = true ] && [ "$deletions_only" = true ]; then
+    echo "ℹ️  ブランチ削除のみの push のため品質ゲートをスキップします"
+    exit 0
+  fi
+fi
+
 echo "Running quality gate before push (npm run quality:local)..."
 echo "  緊急時のみ: SKIP_QUALITY_GATE=1 git push で回避可"
 

--- a/scripts/review-common.sh
+++ b/scripts/review-common.sh
@@ -73,9 +73,10 @@ prepare_diff() {
     esac
 }
 
-# Exclude auto-generated/lock files from review scope
+# Exclude auto-generated/lock files from review scope.
+# lock ファイルはどの階層でも除外（ルート直下だけでなく mcp/package-lock.json 等も）。
 _filter_review_files() {
-    echo "$1" | grep -vE '^(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|.*\.generated\..*)$' || true
+    echo "$1" | grep -vE '(^|/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$|\.generated\.' || true
 }
 
 _prepare_staged_diff() {

--- a/scripts/review-scripts.test.ts
+++ b/scripts/review-scripts.test.ts
@@ -422,4 +422,11 @@ describe(".husky/pre-push の品質ゲート分岐（スタブ npm）", () => {
     expect(r.status).toBe(1);
     expect(r.output).toContain("品質ゲート失敗");
   });
+
+  it("フィールド欠落（空 local_sha）は削除扱いにせずゲートを実行（fail-closed）— Issue #461", () => {
+    // sha フィールドが欠けた想定外の stdin。削除誤判定でゲートを回避しないこと
+    const r = runPrePush(1, {}, `refs/heads/x\n`);
+    expect(r.status).toBe(1);
+    expect(r.output).toContain("品質ゲート失敗");
+  });
 });

--- a/scripts/review-scripts.test.ts
+++ b/scripts/review-scripts.test.ts
@@ -338,10 +338,34 @@ describe("review-common.sh のフェイルセーフ（代表: claude-review.sh�
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("サブディレクトリの lockfile（mcp/package-lock.json）のみもスキップ（exit 0）— Issue #457", () => {
+    const dir = mkdtempSync(join(tmpdir(), "review-sublock-"));
+    try {
+      const git = initGitRepo(dir);
+      git("checkout", "-b", "feature/sublock");
+      mkdirSync(join(dir, "mcp"), { recursive: true });
+      writeFileSync(join(dir, "mcp", "package-lock.json"), "{}\n");
+      git("add", ".");
+      git("commit", "-m", "chore: sub lockfile update");
+      const r = runReview("claude-review.sh", ["--branch"], {
+        cwd: dir,
+        path: `${passStubDir}:${BASE_PATH}`,
+        env: { REVIEW_BASE_BRANCH: "develop" },
+      });
+      expect(r.status).toBe(0);
+      expect(r.output).toMatch(/Only auto-generated files/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe(".husky/pre-push の品質ゲート分岐（スタブ npm）", () => {
-  function runPrePush(npmExitCode: number | null, env: Record<string, string> = {}) {
+  const ZERO_SHA = "0".repeat(40);
+  const REAL_SHA = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+  function runPrePush(npmExitCode: number | null, env: Record<string, string> = {}, input?: string) {
     const dir = mkdtempSync(join(tmpdir(), "prepush-stub-"));
     try {
       if (npmExitCode !== null) {
@@ -354,6 +378,7 @@ describe(".husky/pre-push の品質ゲート分岐（スタブ npm）", () => {
         encoding: "utf8",
         timeout: 30_000,
         env: { PATH: `${dir}:${BASE_PATH}`, ...env },
+        ...(input === undefined ? {} : { input }),
       });
       return { ...r, output: `${r.stdout}\n${r.stderr}` };
     } finally {
@@ -374,6 +399,26 @@ describe(".husky/pre-push の品質ゲート分岐（スタブ npm）", () => {
 
   it("quality:local 失敗で exit 1（push ブロック）", () => {
     const r = runPrePush(1);
+    expect(r.status).toBe(1);
+    expect(r.output).toContain("品質ゲート失敗");
+  });
+
+  it("ブランチ削除のみの push はゲートをスキップ（npm-fail スタブでも exit 0）— Issue #461", () => {
+    // npm スタブは exit 1（ゲートが走れば失敗）。削除 push なら npm 到達前に skip → exit 0
+    const r = runPrePush(1, {}, `refs/heads/x ${ZERO_SHA} refs/heads/x ${ZERO_SHA}\n`);
+    expect(r.status).toBe(0);
+    expect(r.output).toContain("ブランチ削除");
+  });
+
+  it("削除と通常 push が混在する場合はゲートを実行（npm-fail で exit 1）— Issue #461", () => {
+    const stdin = `refs/heads/a ${ZERO_SHA} refs/heads/a ${ZERO_SHA}\nrefs/heads/b ${REAL_SHA} refs/heads/b ${ZERO_SHA}\n`;
+    const r = runPrePush(1, {}, stdin);
+    expect(r.status).toBe(1);
+    expect(r.output).toContain("品質ゲート失敗");
+  });
+
+  it("通常 push（非ゼロ sha）はゲートを実行する — Issue #461", () => {
+    const r = runPrePush(1, {}, `refs/heads/x ${REAL_SHA} refs/heads/x ${ZERO_SHA}\n`);
     expect(r.status).toBe(1);
     expect(r.output).toContain("品質ゲート失敗");
   });


### PR DESCRIPTION
Closes #457
Closes #461

小粒な review-infra 修正2件を1本にまとめました（どちらも同じ review スクリプト群 + テストファイルに触れるため）。

## 変更内容

### #457: 生成物除外フィルタのサブディレクトリ対応
`review-common.sh` の `_filter_review_files` が `^package-lock.json$` とルート直下にアンカーされ、`mcp/package-lock.json` 等が除外されず巨大 diff が LLM に流れていた。`(^|/)(...)$` で全階層の lock ファイルを除外。

### #461: pre-push を削除 push でスキップ
マージ後 cleanup の `git push origin --delete` でも品質ゲート（1〜2分）が走っていた。pre-push の stdin から各 ref の local sha を読み、**全ゼロ（削除）のみ**の push はゲートをスキップ。stdin 空（手動実行・テスト）は `saw_ref=false` でゲートへ進む後方互換設計。sha 全ゼロ判定は `case *[!0]*` で SHA-1/SHA-256 の桁数差に非依存。

## テスト（45→49）

- サブディレクトリ lockfile（mcp/package-lock.json）のスキップ
- 削除 push スキップ（**npm-fail スタブでも exit 0** = ゲート未到達を証明）
- 削除+通常の混在 → ゲート実行（exit 1）
- 通常 push（非ゼロ sha）→ ゲート実行

## レビュー深度

`bash scripts/review-level.sh` → **Level 3**（scripts/ + .husky/ に touch）。Toolkit + Codex でレビュー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)