### PR TITLE
fix: #450 multi-agent.sh のレポートに前回実行の stale 結果が混入するのを防ぐ

### DIFF
--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -628,17 +628,18 @@ HEADER
   local has_results=false
 
   # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is therefore never read, and nothing on
-  # disk is deleted or touched — so re-running with a shared --output-dir, or a
-  # partial --cli/--perspective run, is non-destructive.
+  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is never read, and no result file is
+  # deleted or modified — the report only reads result files and writes
+  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
+  # run, is non-destructive. A planned entry whose output file is missing (CLI
+  # failure or name mismatch) is surfaced in the report, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
-    [[ -f "$result_file" ]] || continue
     has_results=true
 
     local tier
@@ -648,7 +649,11 @@ HEADER
       echo ""
       echo "## ${cli_name} — ${perspective_name} [${tier}]"
       echo ""
-      cat "$result_file"
+      if [[ -f "$result_file" ]]; then
+        cat "$result_file"
+      else
+        echo "⚠️ No output produced by this task (CLI failure or missing result file)."
+      fi
       echo ""
       echo "---"
       echo ""
@@ -689,17 +694,18 @@ HEADER
   local has_results=false
 
   # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is therefore never read, and nothing on
-  # disk is deleted or touched — so re-running with a shared --output-dir, or a
-  # partial --cli/--perspective run, is non-destructive.
+  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is never read, and no result file is
+  # deleted or modified — the report only reads result files and writes
+  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
+  # run, is non-destructive. A planned entry whose output file is missing (CLI
+  # failure or name mismatch) is surfaced in the report, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
-    [[ -f "$result_file" ]] || continue
     has_results=true
 
     local tier
@@ -709,7 +715,11 @@ HEADER
       echo ""
       echo "## ${cli_name} — ${perspective_name} [${tier}]"
       echo ""
-      cat "$result_file"
+      if [[ -f "$result_file" ]]; then
+        cat "$result_file"
+      else
+        echo "⚠️ No output produced by this task (CLI failure or missing result file)."
+      fi
       echo ""
       echo "---"
       echo ""
@@ -748,17 +758,18 @@ HEADER
   local has_results=false
 
   # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is therefore never read, and nothing on
-  # disk is deleted or touched — so re-running with a shared --output-dir, or a
-  # partial --cli/--perspective run, is non-destructive.
+  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is never read, and no result file is
+  # deleted or modified — the report only reads result files and writes
+  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
+  # run, is non-destructive. A planned entry whose output file is missing (CLI
+  # failure or name mismatch) is surfaced in the report, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
-    [[ -f "$result_file" ]] || continue
     has_results=true
 
     local tier
@@ -768,7 +779,11 @@ HEADER
       echo ""
       echo "## ${cli_name} — ${perspective_name} [${tier}]"
       echo ""
-      cat "$result_file"
+      if [[ -f "$result_file" ]]; then
+        cat "$result_file"
+      else
+        echo "⚠️ No output produced by this task (CLI failure or missing result file)."
+      fi
       echo ""
       echo "---"
       echo ""

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -544,23 +544,44 @@ run_single_task() {
 }
 
 # ── Cleanup Stale Results ──
-# generate_report() collects EVERY *.md under ${OUTPUT_DIR}/${cli}/, so results
-# from a previous run linger and get reported as "this run's" results (issue #450).
-# Remove the prior run's per-CLI result files before executing, so the integrated
-# report contains only the current run. Runs for review/explore/implement alike,
-# since all three share this single execution path.
+# The report builders (generate_{review,explore,implement}_report) each collect
+# EVERY *.md under ${OUTPUT_DIR}/${cli}/, so a perspective produced only by a
+# previous run lingers and is reported as "this run's" result (issue #450).
+# Before executing, delete the prior run's result files so the integrated report
+# reflects only the current run. Covers review/explore/implement alike, since all
+# three converge on this single execution path.
+#
+# We delete only the perspective files THIS script produces for the current task
+# type — mirroring resolve_perspective_file's lookup (task-type subdir + root
+# fallback) — instead of a blanket "${cli_dir}"/*.md. That way unrelated Markdown
+# a user keeps under a shared --output-dir is never destroyed.
 cleanup_stale_results() {
   # Defense-in-depth: never operate on an unset/empty OUTPUT_DIR, even though
   # apply_task_defaults guarantees it is populated by this point.
   [[ -n "$OUTPUT_DIR" ]] || return 0
 
+  # Perspective names this task type can emit (task-type subdir + root fallback).
+  local managed_names=()
+  local persp_src persp_file
+  for persp_src in "${SCRIPT_DIR}/perspectives/${TASK_TYPE}" "${SCRIPT_DIR}/perspectives"; do
+    [[ -d "$persp_src" ]] || continue
+    for persp_file in "$persp_src"/*.md; do
+      [[ -f "$persp_file" ]] || continue
+      managed_names+=("$(basename "$persp_file" .md)")
+    done
+  done
+
+  local cli_name persp_name
   for cli_name in $ALL_CLIS; do
     local cli_dir="${OUTPUT_DIR}/${cli_name}"
     [[ -d "$cli_dir" ]] || continue
-
-    # Remove only the per-perspective result files (*.md). `-f` keeps this a
-    # no-op — not an errexit-tripping failure — when the glob matches nothing.
-    rm -f "$cli_dir"/*.md
+    # ":-" guards the empty-array expansion under `set -u` on bash 3.2.
+    for persp_name in "${managed_names[@]:-}"; do
+      [[ -n "$persp_name" ]] || continue
+      # `-f`: not every (cli, perspective) pair produced a file, and a missing
+      # file must be a no-op rather than an errexit-tripping failure.
+      rm -f "${cli_dir}/${persp_name}.md"
+    done
   done
 }
 

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -617,9 +617,14 @@ execute_tasks() {
   local tasks=""
   local failed=0
   local count=0
+  local seen=""
 
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
+    # Skip a duplicate plan entry so the same cli:perspective is not executed
+    # twice (a plan fallback can list it more than once).
+    if [[ " $seen " == *" $entry "* ]]; then continue; fi
+    seen="$seen $entry"
     local cli="${entry%%:*}"
     local persp="${entry#*:}"
 
@@ -633,6 +638,11 @@ execute_tasks() {
       if ! run_single_task "$cli" "$persp"; then
         failed=$((failed + 1))
         echo "  ❌ Failed: ${cli}/${persp}" >&2
+      elif [[ ! -f "${OUTPUT_DIR}/${cli}/${persp}.md" ]]; then
+        # Adapter reported success but wrote no output — count it as a failure so
+        # a silently-empty run shows up in the exit code, not only the report.
+        failed=$((failed + 1))
+        echo "  ❌ No output file: ${cli}/${persp}" >&2
       fi
     fi
   done <<< "$EXECUTION_PLAN"
@@ -649,11 +659,15 @@ execute_tasks() {
       task_name="$(echo "$tasks" | cut -d'|' -f"$idx")"
       wait "$pid"
       exit_code=$?
-      if [[ $exit_code -eq 0 ]]; then
+      if [[ $exit_code -eq 0 && -f "${OUTPUT_DIR}/${task_name}.md" ]]; then
         echo "  ✅ Done: ${task_name}" >&2
-      else
+      elif [[ $exit_code -ne 0 ]]; then
         failed=$((failed + 1))
         echo "  ❌ Failed: ${task_name} (exit code: ${exit_code})" >&2
+      else
+        # Success exit but no output file — surface as a failure, not silent OK.
+        failed=$((failed + 1))
+        echo "  ❌ No output file: ${task_name}" >&2
       fi
     done
     set -e

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -543,58 +543,6 @@ run_single_task() {
     "${extra_args[@]}"
 }
 
-# ── Managed Perspective Names ──
-# The set of perspective basenames THIS script can emit for the current task
-# type — mirroring resolve_perspective_file's lookup (task-type subdir + root
-# fallback). Echoed space-delimited. Both cleanup and report generation key off
-# this same set so they agree on what counts as "a result of this tool".
-managed_perspective_names() {
-  local names="" persp_src persp_file
-  for persp_src in "${SCRIPT_DIR}/perspectives/${TASK_TYPE}" "${SCRIPT_DIR}/perspectives"; do
-    [[ -d "$persp_src" ]] || continue
-    for persp_file in "$persp_src"/*.md; do
-      [[ -f "$persp_file" ]] || continue
-      names="${names} $(basename "$persp_file" .md)"
-    done
-  done
-  echo "$names"
-}
-
-# ── Cleanup Stale Results ──
-# The report builders (generate_{review,explore,implement}_report) collect result
-# files under ${OUTPUT_DIR}/${cli}/, so a perspective produced only by a previous
-# run lingers and is reported as "this run's" result (issue #450). Before
-# executing, delete the prior run's result files so the integrated report reflects
-# only the current run. Covers review/explore/implement alike, since all three
-# converge on this single execution path.
-#
-# Delete only the perspective files THIS script manages (managed_perspective_names)
-# rather than a blanket "${cli_dir}"/*.md — unrelated Markdown a user keeps under a
-# shared --output-dir is never destroyed. Non-managed leftovers that survive here
-# (e.g. a renamed perspective, or a dir reused across task types) are handled on
-# the read side: the report ignores any *.md that is not a managed perspective, so
-# they cannot leak into the report either.
-cleanup_stale_results() {
-  # Defense-in-depth: never operate on an unset/empty OUTPUT_DIR ("${x:-}" keeps
-  # this safe under `set -u` when unset), even though apply_task_defaults
-  # guarantees it is populated by this point.
-  [[ -n "${OUTPUT_DIR:-}" ]] || return 0
-
-  local managed
-  managed="$(managed_perspective_names)"
-
-  local cli_name persp_name
-  for cli_name in $ALL_CLIS; do
-    local cli_dir="${OUTPUT_DIR}/${cli_name}"
-    [[ -d "$cli_dir" ]] || continue
-    for persp_name in $managed; do
-      # `-f`: not every (cli, perspective) pair produced a file, and a missing
-      # file must be a no-op rather than an errexit-tripping failure.
-      rm -f "${cli_dir}/${persp_name}.md"
-    done
-  done
-}
-
 # ── Execute All Tasks ──
 execute_tasks() {
   if [[ -z "$EXECUTION_PLAN" ]]; then
@@ -603,7 +551,6 @@ execute_tasks() {
   fi
 
   mkdir -p "$OUTPUT_DIR"
-  cleanup_stale_results
 
   local pids=""
   local tasks=""
@@ -679,38 +626,34 @@ generate_review_report() {
 HEADER
 
   local has_results=false
-  local managed
-  managed="$(managed_perspective_names)"
 
-  for cli_name in $ALL_CLIS; do
-    local cli_dir="${OUTPUT_DIR}/${cli_name}"
-    [[ -d "$cli_dir" ]] || continue
+  # issue #450: include exactly the results THIS run produced by iterating the
+  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is therefore never read, and nothing on
+  # disk is deleted or touched — so re-running with a shared --output-dir, or a
+  # partial --cli/--perspective run, is non-destructive.
+  local entry
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    local cli_name="${entry%%:*}"
+    local perspective_name="${entry#*:}"
+    local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
+    [[ -f "$result_file" ]] || continue
+    has_results=true
 
-    for result_file in "${cli_dir}"/*.md; do
-      [[ -f "$result_file" ]] || continue
+    local tier
+    tier="$(get_cli_cost_tier "$cli_name")"
 
-      local perspective_name
-      perspective_name="$(basename "$result_file" .md)"
-      # issue #450: only surface perspectives this task type manages; a stray or
-      # stale *.md (renamed perspective, a dir reused across task types, or a
-      # user's own file under a shared --output-dir) must not leak into the report.
-      [[ " $managed " == *" ${perspective_name} "* ]] || continue
-      has_results=true
-
-      local tier
-      tier="$(get_cli_cost_tier "$cli_name")"
-
-      {
-        echo ""
-        echo "## ${cli_name} — ${perspective_name} [${tier}]"
-        echo ""
-        cat "$result_file"
-        echo ""
-        echo "---"
-        echo ""
-      } >> "$report_file"
-    done
-  done
+    {
+      echo ""
+      echo "## ${cli_name} — ${perspective_name} [${tier}]"
+      echo ""
+      cat "$result_file"
+      echo ""
+      echo "---"
+      echo ""
+    } >> "$report_file"
+  done <<< "$EXECUTION_PLAN"
 
   if [[ "$has_results" == "false" ]]; then
     echo "(No review results found.)" >> "$report_file"
@@ -744,38 +687,34 @@ generate_explore_report() {
 HEADER
 
   local has_results=false
-  local managed
-  managed="$(managed_perspective_names)"
 
-  for cli_name in $ALL_CLIS; do
-    local cli_dir="${OUTPUT_DIR}/${cli_name}"
-    [[ -d "$cli_dir" ]] || continue
+  # issue #450: include exactly the results THIS run produced by iterating the
+  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is therefore never read, and nothing on
+  # disk is deleted or touched — so re-running with a shared --output-dir, or a
+  # partial --cli/--perspective run, is non-destructive.
+  local entry
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    local cli_name="${entry%%:*}"
+    local perspective_name="${entry#*:}"
+    local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
+    [[ -f "$result_file" ]] || continue
+    has_results=true
 
-    for result_file in "${cli_dir}"/*.md; do
-      [[ -f "$result_file" ]] || continue
+    local tier
+    tier="$(get_cli_cost_tier "$cli_name")"
 
-      local perspective_name
-      perspective_name="$(basename "$result_file" .md)"
-      # issue #450: only surface perspectives this task type manages; a stray or
-      # stale *.md (renamed perspective, a dir reused across task types, or a
-      # user's own file under a shared --output-dir) must not leak into the report.
-      [[ " $managed " == *" ${perspective_name} "* ]] || continue
-      has_results=true
-
-      local tier
-      tier="$(get_cli_cost_tier "$cli_name")"
-
-      {
-        echo ""
-        echo "## ${cli_name} — ${perspective_name} [${tier}]"
-        echo ""
-        cat "$result_file"
-        echo ""
-        echo "---"
-        echo ""
-      } >> "$report_file"
-    done
-  done
+    {
+      echo ""
+      echo "## ${cli_name} — ${perspective_name} [${tier}]"
+      echo ""
+      cat "$result_file"
+      echo ""
+      echo "---"
+      echo ""
+    } >> "$report_file"
+  done <<< "$EXECUTION_PLAN"
 
   if [[ "$has_results" == "false" ]]; then
     echo "(No explore results found.)" >> "$report_file"
@@ -807,38 +746,34 @@ generate_implement_report() {
 HEADER
 
   local has_results=false
-  local managed
-  managed="$(managed_perspective_names)"
 
-  for cli_name in $ALL_CLIS; do
-    local cli_dir="${OUTPUT_DIR}/${cli_name}"
-    [[ -d "$cli_dir" ]] || continue
+  # issue #450: include exactly the results THIS run produced by iterating the
+  # execution plan, instead of globbing ${cli}/*.md. A prior run's stale
+  # perspective (absent from this plan) is therefore never read, and nothing on
+  # disk is deleted or touched — so re-running with a shared --output-dir, or a
+  # partial --cli/--perspective run, is non-destructive.
+  local entry
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    local cli_name="${entry%%:*}"
+    local perspective_name="${entry#*:}"
+    local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
+    [[ -f "$result_file" ]] || continue
+    has_results=true
 
-    for result_file in "${cli_dir}"/*.md; do
-      [[ -f "$result_file" ]] || continue
+    local tier
+    tier="$(get_cli_cost_tier "$cli_name")"
 
-      local perspective_name
-      perspective_name="$(basename "$result_file" .md)"
-      # issue #450: only surface perspectives this task type manages; a stray or
-      # stale *.md (renamed perspective, a dir reused across task types, or a
-      # user's own file under a shared --output-dir) must not leak into the report.
-      [[ " $managed " == *" ${perspective_name} "* ]] || continue
-      has_results=true
-
-      local tier
-      tier="$(get_cli_cost_tier "$cli_name")"
-
-      {
-        echo ""
-        echo "## ${cli_name} — ${perspective_name} [${tier}]"
-        echo ""
-        cat "$result_file"
-        echo ""
-        echo "---"
-        echo ""
-      } >> "$report_file"
-    done
-  done
+    {
+      echo ""
+      echo "## ${cli_name} — ${perspective_name} [${tier}]"
+      echo ""
+      cat "$result_file"
+      echo ""
+      echo "---"
+      echo ""
+    } >> "$report_file"
+  done <<< "$EXECUTION_PLAN"
 
   if [[ "$has_results" == "false" ]]; then
     echo "(No implement results found.)" >> "$report_file"

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -551,6 +551,27 @@ is_safe_token() {
   [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] && [[ "$1" != "." && "$1" != ".." ]]
 }
 
+# ── Validate Execution Plan ──
+# Fail loud (never a silent skip) if any plan entry carries a cli/perspective
+# token that is not a safe single path segment. Called once at each consumption
+# entry point (execute_tasks, generate_report) BEFORE the plan is used, so a
+# crafted --cli/--perspective value cannot reach the execute (write), cleanup, or
+# report (read) paths and escape OUTPUT_DIR — and a malformed plan surfaces as an
+# error instead of silently collapsing to "(No results found.)".
+validate_execution_plan() {
+  local entry cli_name persp_name bad=0
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    cli_name="${entry%%:*}"
+    persp_name="${entry#*:}"
+    if ! is_safe_token "$cli_name" || ! is_safe_token "$persp_name"; then
+      echo "ERROR: unsafe token in execution plan entry: '${entry}'" >&2
+      bad=1
+    fi
+  done <<< "$EXECUTION_PLAN"
+  [[ "$bad" -eq 0 ]]
+}
+
 # ── Clear This Run's Planned Outputs ──
 # The report reads ${cli}/${perspective}.md for each plan entry; adapters only
 # (over)write that file on success, leaving a prior run's file in place on
@@ -558,7 +579,8 @@ is_safe_token() {
 # that produces no output leaves NO stale same-name file to be mis-reported as
 # current (issue #450) — instead the report surfaces it as "no output". Scoped to
 # the plan's own (cli, perspective) targets only; nothing else on disk (other
-# CLIs, other perspectives, unrelated user files) is touched.
+# CLIs, other perspectives, unrelated user files) is touched. Callers run
+# validate_execution_plan first, so every token here is already a safe segment.
 clear_planned_outputs() {
   [[ -n "${OUTPUT_DIR:-}" ]] || return 0
   local entry cli_name persp_name
@@ -566,9 +588,6 @@ clear_planned_outputs() {
     [[ -z "$entry" ]] && continue
     cli_name="${entry%%:*}"
     persp_name="${entry#*:}"
-    if ! is_safe_token "$cli_name" || ! is_safe_token "$persp_name"; then
-      continue
-    fi
     rm -f "${OUTPUT_DIR}/${cli_name}/${persp_name}.md"
   done <<< "$EXECUTION_PLAN"
 }
@@ -579,6 +598,9 @@ execute_tasks() {
     echo "Nothing to execute." >&2
     return 0
   fi
+
+  # Reject a plan with unsafe path segments before writing/deleting anything.
+  validate_execution_plan || return 1
 
   mkdir -p "$OUTPUT_DIR"
   clear_planned_outputs
@@ -672,11 +694,8 @@ HEADER
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Never build a path from an unsafe segment (guards report against a crafted
-    # --cli/--perspective traversal such as "../../secret").
-    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
-      continue
-    fi
+    # Tokens are already validated by validate_execution_plan (called from the
+    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -745,11 +764,8 @@ HEADER
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Never build a path from an unsafe segment (guards report against a crafted
-    # --cli/--perspective traversal such as "../../secret").
-    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
-      continue
-    fi
+    # Tokens are already validated by validate_execution_plan (called from the
+    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -816,11 +832,8 @@ HEADER
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Never build a path from an unsafe segment (guards report against a crafted
-    # --cli/--perspective traversal such as "../../secret").
-    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
-      continue
-    fi
+    # Tokens are already validated by validate_execution_plan (called from the
+    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -851,6 +864,8 @@ HEADER
 
 # ── Generate Report (dispatcher) ──
 generate_report() {
+  # Reject a plan with unsafe path segments before any builder reads from it.
+  validate_execution_plan || return 1
   case "$TASK_TYPE" in
     review)    generate_review_report ;;
     explore)   generate_explore_report ;;

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -543,6 +543,36 @@ run_single_task() {
     "${extra_args[@]}"
 }
 
+# ── Path-Segment Safety ──
+# A CLI / perspective name is used as a single path segment under OUTPUT_DIR.
+# Reject anything that is not a plain identifier so a crafted --cli/--perspective
+# value (e.g. "../../secret") cannot escape OUTPUT_DIR when we build result paths.
+is_safe_token() {
+  [[ "$1" =~ ^[A-Za-z0-9._-]+$ ]] && [[ "$1" != "." && "$1" != ".." ]]
+}
+
+# ── Clear This Run's Planned Outputs ──
+# The report reads ${cli}/${perspective}.md for each plan entry; adapters only
+# (over)write that file on success, leaving a prior run's file in place on
+# failure/timeout. Deleting exactly this run's own targets up front means a task
+# that produces no output leaves NO stale same-name file to be mis-reported as
+# current (issue #450) — instead the report surfaces it as "no output". Scoped to
+# the plan's own (cli, perspective) targets only; nothing else on disk (other
+# CLIs, other perspectives, unrelated user files) is touched.
+clear_planned_outputs() {
+  [[ -n "${OUTPUT_DIR:-}" ]] || return 0
+  local entry cli_name persp_name
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    cli_name="${entry%%:*}"
+    persp_name="${entry#*:}"
+    if ! is_safe_token "$cli_name" || ! is_safe_token "$persp_name"; then
+      continue
+    fi
+    rm -f "${OUTPUT_DIR}/${cli_name}/${persp_name}.md"
+  done <<< "$EXECUTION_PLAN"
+}
+
 # ── Execute All Tasks ──
 execute_tasks() {
   if [[ -z "$EXECUTION_PLAN" ]]; then
@@ -551,6 +581,7 @@ execute_tasks() {
   fi
 
   mkdir -p "$OUTPUT_DIR"
+  clear_planned_outputs
 
   local pids=""
   local tasks=""
@@ -627,18 +658,25 @@ HEADER
 
   local has_results=false
 
-  # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is never read, and no result file is
-  # deleted or modified — the report only reads result files and writes
-  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
-  # run, is non-destructive. A planned entry whose output file is missing (CLI
-  # failure or name mismatch) is surfaced in the report, not silently dropped.
+  # issue #450: report exactly THIS run's entries by iterating the execution plan
+  # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
+  # read, and each entry's target file was cleared before execution
+  # (clear_planned_outputs), so a prior run's result — whether a different
+  # perspective or a same-named stale file left by a failed task — cannot appear
+  # as current. The report only reads result files and writes report_file; no
+  # result file is deleted or modified here, so a shared --output-dir re-run or a
+  # partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
+    # Never build a path from an unsafe segment (guards report against a crafted
+    # --cli/--perspective traversal such as "../../secret").
+    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
+      continue
+    fi
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -693,18 +731,25 @@ HEADER
 
   local has_results=false
 
-  # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is never read, and no result file is
-  # deleted or modified — the report only reads result files and writes
-  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
-  # run, is non-destructive. A planned entry whose output file is missing (CLI
-  # failure or name mismatch) is surfaced in the report, not silently dropped.
+  # issue #450: report exactly THIS run's entries by iterating the execution plan
+  # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
+  # read, and each entry's target file was cleared before execution
+  # (clear_planned_outputs), so a prior run's result — whether a different
+  # perspective or a same-named stale file left by a failed task — cannot appear
+  # as current. The report only reads result files and writes report_file; no
+  # result file is deleted or modified here, so a shared --output-dir re-run or a
+  # partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
+    # Never build a path from an unsafe segment (guards report against a crafted
+    # --cli/--perspective traversal such as "../../secret").
+    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
+      continue
+    fi
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -757,18 +802,25 @@ HEADER
 
   local has_results=false
 
-  # issue #450: include exactly the results THIS run produced by iterating the
-  # execution plan instead of globbing ${cli}/*.md. A prior run's stale
-  # perspective (absent from this plan) is never read, and no result file is
-  # deleted or modified — the report only reads result files and writes
-  # report_file. So a shared --output-dir re-run, or a partial --cli/--perspective
-  # run, is non-destructive. A planned entry whose output file is missing (CLI
-  # failure or name mismatch) is surfaced in the report, not silently dropped.
+  # issue #450: report exactly THIS run's entries by iterating the execution plan
+  # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
+  # read, and each entry's target file was cleared before execution
+  # (clear_planned_outputs), so a prior run's result — whether a different
+  # perspective or a same-named stale file left by a failed task — cannot appear
+  # as current. The report only reads result files and writes report_file; no
+  # result file is deleted or modified here, so a shared --output-dir re-run or a
+  # partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped.
   local entry
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
+    # Never build a path from an unsafe segment (guards report against a crafted
+    # --cli/--perspective traversal such as "../../secret").
+    if ! is_safe_token "$cli_name" || ! is_safe_token "$perspective_name"; then
+      continue
+    fi
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -562,6 +562,14 @@ validate_execution_plan() {
   local entry cli_name persp_name bad=0
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
+    # Require the exact "cli:perspective" shape. Without a ':', ${entry%%:*} and
+    # ${entry#*:} both collapse to the whole string, so a malformed entry would
+    # otherwise pass and drive read/delete/write at the wrong path.
+    if [[ "$entry" != *:* ]]; then
+      echo "ERROR: malformed execution plan entry (expected 'cli:perspective'): '${entry}'" >&2
+      bad=1
+      continue
+    fi
     cli_name="${entry%%:*}"
     persp_name="${entry#*:}"
     if ! is_safe_token "$cli_name" || ! is_safe_token "$persp_name"; then
@@ -682,20 +690,24 @@ HEADER
 
   # issue #450: report exactly THIS run's entries by iterating the execution plan
   # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
-  # read, and each entry's target file was cleared before execution
-  # (clear_planned_outputs), so a prior run's result — whether a different
-  # perspective or a same-named stale file left by a failed task — cannot appear
-  # as current. The report only reads result files and writes report_file; no
-  # result file is deleted or modified here, so a shared --output-dir re-run or a
-  # partial --cli/--perspective run is non-destructive. A planned entry with no
-  # output file (CLI failure) is surfaced, not silently dropped.
-  local entry
+  # read. In the normal flow execute_tasks clears each entry's target before
+  # running (clear_planned_outputs), so a prior run's result — a different
+  # perspective, or a same-named stale file left by a failed task — does not
+  # appear as current. The report only reads result files and writes report_file;
+  # no result file is deleted or modified here, so a shared --output-dir re-run or
+  # a partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped. The generate_report
+  # dispatcher validates every token before dispatching here.
+  local entry seen=""
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
+    # Skip a duplicate plan entry so a repeated cli:perspective (e.g. a plan
+    # fallback that reassigns a perspective to an already-listed CLI) is not
+    # pasted into the report twice.
+    if [[ " $seen " == *" $entry "* ]]; then continue; fi
+    seen="$seen $entry"
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Tokens are already validated by validate_execution_plan (called from the
-    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -752,20 +764,24 @@ HEADER
 
   # issue #450: report exactly THIS run's entries by iterating the execution plan
   # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
-  # read, and each entry's target file was cleared before execution
-  # (clear_planned_outputs), so a prior run's result — whether a different
-  # perspective or a same-named stale file left by a failed task — cannot appear
-  # as current. The report only reads result files and writes report_file; no
-  # result file is deleted or modified here, so a shared --output-dir re-run or a
-  # partial --cli/--perspective run is non-destructive. A planned entry with no
-  # output file (CLI failure) is surfaced, not silently dropped.
-  local entry
+  # read. In the normal flow execute_tasks clears each entry's target before
+  # running (clear_planned_outputs), so a prior run's result — a different
+  # perspective, or a same-named stale file left by a failed task — does not
+  # appear as current. The report only reads result files and writes report_file;
+  # no result file is deleted or modified here, so a shared --output-dir re-run or
+  # a partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped. The generate_report
+  # dispatcher validates every token before dispatching here.
+  local entry seen=""
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
+    # Skip a duplicate plan entry so a repeated cli:perspective (e.g. a plan
+    # fallback that reassigns a perspective to an already-listed CLI) is not
+    # pasted into the report twice.
+    if [[ " $seen " == *" $entry "* ]]; then continue; fi
+    seen="$seen $entry"
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Tokens are already validated by validate_execution_plan (called from the
-    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 
@@ -820,20 +836,24 @@ HEADER
 
   # issue #450: report exactly THIS run's entries by iterating the execution plan
   # instead of globbing ${cli}/*.md. A perspective absent from this plan is never
-  # read, and each entry's target file was cleared before execution
-  # (clear_planned_outputs), so a prior run's result — whether a different
-  # perspective or a same-named stale file left by a failed task — cannot appear
-  # as current. The report only reads result files and writes report_file; no
-  # result file is deleted or modified here, so a shared --output-dir re-run or a
-  # partial --cli/--perspective run is non-destructive. A planned entry with no
-  # output file (CLI failure) is surfaced, not silently dropped.
-  local entry
+  # read. In the normal flow execute_tasks clears each entry's target before
+  # running (clear_planned_outputs), so a prior run's result — a different
+  # perspective, or a same-named stale file left by a failed task — does not
+  # appear as current. The report only reads result files and writes report_file;
+  # no result file is deleted or modified here, so a shared --output-dir re-run or
+  # a partial --cli/--perspective run is non-destructive. A planned entry with no
+  # output file (CLI failure) is surfaced, not silently dropped. The generate_report
+  # dispatcher validates every token before dispatching here.
+  local entry seen=""
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
+    # Skip a duplicate plan entry so a repeated cli:perspective (e.g. a plan
+    # fallback that reassigns a perspective to an already-listed CLI) is not
+    # pasted into the report twice.
+    if [[ " $seen " == *" $entry "* ]]; then continue; fi
+    seen="$seen $entry"
     local cli_name="${entry%%:*}"
     local perspective_name="${entry#*:}"
-    # Tokens are already validated by validate_execution_plan (called from the
-    # generate_report dispatcher) before we build any path from them.
     local result_file="${OUTPUT_DIR}/${cli_name}/${perspective_name}.md"
     has_results=true
 

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -543,41 +543,51 @@ run_single_task() {
     "${extra_args[@]}"
 }
 
-# ── Cleanup Stale Results ──
-# The report builders (generate_{review,explore,implement}_report) each collect
-# EVERY *.md under ${OUTPUT_DIR}/${cli}/, so a perspective produced only by a
-# previous run lingers and is reported as "this run's" result (issue #450).
-# Before executing, delete the prior run's result files so the integrated report
-# reflects only the current run. Covers review/explore/implement alike, since all
-# three converge on this single execution path.
-#
-# We delete only the perspective files THIS script produces for the current task
+# ── Managed Perspective Names ──
+# The set of perspective basenames THIS script can emit for the current task
 # type — mirroring resolve_perspective_file's lookup (task-type subdir + root
-# fallback) — instead of a blanket "${cli_dir}"/*.md. That way unrelated Markdown
-# a user keeps under a shared --output-dir is never destroyed.
-cleanup_stale_results() {
-  # Defense-in-depth: never operate on an unset/empty OUTPUT_DIR, even though
-  # apply_task_defaults guarantees it is populated by this point.
-  [[ -n "$OUTPUT_DIR" ]] || return 0
-
-  # Perspective names this task type can emit (task-type subdir + root fallback).
-  local managed_names=()
-  local persp_src persp_file
+# fallback). Echoed space-delimited. Both cleanup and report generation key off
+# this same set so they agree on what counts as "a result of this tool".
+managed_perspective_names() {
+  local names="" persp_src persp_file
   for persp_src in "${SCRIPT_DIR}/perspectives/${TASK_TYPE}" "${SCRIPT_DIR}/perspectives"; do
     [[ -d "$persp_src" ]] || continue
     for persp_file in "$persp_src"/*.md; do
       [[ -f "$persp_file" ]] || continue
-      managed_names+=("$(basename "$persp_file" .md)")
+      names="${names} $(basename "$persp_file" .md)"
     done
   done
+  echo "$names"
+}
+
+# ── Cleanup Stale Results ──
+# The report builders (generate_{review,explore,implement}_report) collect result
+# files under ${OUTPUT_DIR}/${cli}/, so a perspective produced only by a previous
+# run lingers and is reported as "this run's" result (issue #450). Before
+# executing, delete the prior run's result files so the integrated report reflects
+# only the current run. Covers review/explore/implement alike, since all three
+# converge on this single execution path.
+#
+# Delete only the perspective files THIS script manages (managed_perspective_names)
+# rather than a blanket "${cli_dir}"/*.md — unrelated Markdown a user keeps under a
+# shared --output-dir is never destroyed. Non-managed leftovers that survive here
+# (e.g. a renamed perspective, or a dir reused across task types) are handled on
+# the read side: the report ignores any *.md that is not a managed perspective, so
+# they cannot leak into the report either.
+cleanup_stale_results() {
+  # Defense-in-depth: never operate on an unset/empty OUTPUT_DIR ("${x:-}" keeps
+  # this safe under `set -u` when unset), even though apply_task_defaults
+  # guarantees it is populated by this point.
+  [[ -n "${OUTPUT_DIR:-}" ]] || return 0
+
+  local managed
+  managed="$(managed_perspective_names)"
 
   local cli_name persp_name
   for cli_name in $ALL_CLIS; do
     local cli_dir="${OUTPUT_DIR}/${cli_name}"
     [[ -d "$cli_dir" ]] || continue
-    # ":-" guards the empty-array expansion under `set -u` on bash 3.2.
-    for persp_name in "${managed_names[@]:-}"; do
-      [[ -n "$persp_name" ]] || continue
+    for persp_name in $managed; do
       # `-f`: not every (cli, perspective) pair produced a file, and a missing
       # file must be a no-op rather than an errexit-tripping failure.
       rm -f "${cli_dir}/${persp_name}.md"
@@ -669,6 +679,8 @@ generate_review_report() {
 HEADER
 
   local has_results=false
+  local managed
+  managed="$(managed_perspective_names)"
 
   for cli_name in $ALL_CLIS; do
     local cli_dir="${OUTPUT_DIR}/${cli_name}"
@@ -676,10 +688,15 @@ HEADER
 
     for result_file in "${cli_dir}"/*.md; do
       [[ -f "$result_file" ]] || continue
-      has_results=true
 
       local perspective_name
       perspective_name="$(basename "$result_file" .md)"
+      # issue #450: only surface perspectives this task type manages; a stray or
+      # stale *.md (renamed perspective, a dir reused across task types, or a
+      # user's own file under a shared --output-dir) must not leak into the report.
+      [[ " $managed " == *" ${perspective_name} "* ]] || continue
+      has_results=true
+
       local tier
       tier="$(get_cli_cost_tier "$cli_name")"
 
@@ -727,6 +744,8 @@ generate_explore_report() {
 HEADER
 
   local has_results=false
+  local managed
+  managed="$(managed_perspective_names)"
 
   for cli_name in $ALL_CLIS; do
     local cli_dir="${OUTPUT_DIR}/${cli_name}"
@@ -734,10 +753,15 @@ HEADER
 
     for result_file in "${cli_dir}"/*.md; do
       [[ -f "$result_file" ]] || continue
-      has_results=true
 
       local perspective_name
       perspective_name="$(basename "$result_file" .md)"
+      # issue #450: only surface perspectives this task type manages; a stray or
+      # stale *.md (renamed perspective, a dir reused across task types, or a
+      # user's own file under a shared --output-dir) must not leak into the report.
+      [[ " $managed " == *" ${perspective_name} "* ]] || continue
+      has_results=true
+
       local tier
       tier="$(get_cli_cost_tier "$cli_name")"
 
@@ -783,6 +807,8 @@ generate_implement_report() {
 HEADER
 
   local has_results=false
+  local managed
+  managed="$(managed_perspective_names)"
 
   for cli_name in $ALL_CLIS; do
     local cli_dir="${OUTPUT_DIR}/${cli_name}"
@@ -790,10 +816,15 @@ HEADER
 
     for result_file in "${cli_dir}"/*.md; do
       [[ -f "$result_file" ]] || continue
-      has_results=true
 
       local perspective_name
       perspective_name="$(basename "$result_file" .md)"
+      # issue #450: only surface perspectives this task type manages; a stray or
+      # stale *.md (renamed perspective, a dir reused across task types, or a
+      # user's own file under a shared --output-dir) must not leak into the report.
+      [[ " $managed " == *" ${perspective_name} "* ]] || continue
+      has_results=true
+
       local tier
       tier="$(get_cli_cost_tier "$cli_name")"
 

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -543,6 +543,27 @@ run_single_task() {
     "${extra_args[@]}"
 }
 
+# ── Cleanup Stale Results ──
+# generate_report() collects EVERY *.md under ${OUTPUT_DIR}/${cli}/, so results
+# from a previous run linger and get reported as "this run's" results (issue #450).
+# Remove the prior run's per-CLI result files before executing, so the integrated
+# report contains only the current run. Runs for review/explore/implement alike,
+# since all three share this single execution path.
+cleanup_stale_results() {
+  # Defense-in-depth: never operate on an unset/empty OUTPUT_DIR, even though
+  # apply_task_defaults guarantees it is populated by this point.
+  [[ -n "$OUTPUT_DIR" ]] || return 0
+
+  for cli_name in $ALL_CLIS; do
+    local cli_dir="${OUTPUT_DIR}/${cli_name}"
+    [[ -d "$cli_dir" ]] || continue
+
+    # Remove only the per-perspective result files (*.md). `-f` keeps this a
+    # no-op — not an errexit-tripping failure — when the glob matches nothing.
+    rm -f "$cli_dir"/*.md
+  done
+}
+
 # ── Execute All Tasks ──
 execute_tasks() {
   if [[ -z "$EXECUTION_PLAN" ]]; then
@@ -551,6 +572,7 @@ execute_tasks() {
   fi
 
   mkdir -p "$OUTPUT_DIR"
+  cleanup_stale_results
 
   local pids=""
   local tasks=""

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -190,16 +190,22 @@ describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
           "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
           'OUTPUT_DIR="$WORKDIR/.review-results"',
           'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/claude-code"',
-          "# run 1: codex-cli で security-analysis + code-review、claude-code で test-analysis",
+          "# run 1: 実行された managed perspective（codex-cli / claude-code 跨ぎ）",
           'echo STALE-CODEX-SEC   > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
           'echo RUN1-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
           'echo STALE-CLAUDE-TEST > "$OUTPUT_DIR/claude-code/test-analysis.md"',
+          "# 非 managed な残骸: 別 task type の perspective 結果とユーザー自身の Markdown",
+          'echo STALE-EXPLORE > "$OUTPUT_DIR/codex-cli/api-surface-analysis.md"',
+          'echo USER-NOTES    > "$OUTPUT_DIR/codex-cli/my-notes.md"',
           "generate_review_report >/dev/null 2>&1",
           "# run 2: cleanup 後、codex-cli の code-review のみ実行",
           "cleanup_stale_results",
-          "# 別 CLI に跨って stale が消えること（マルチ CLI 分離）",
+          "# managed stale は両 CLI 跨ぎで削除される（マルチ CLI 分離）",
           'test ! -f "$OUTPUT_DIR/codex-cli/security-analysis.md" || { echo LEAK-CODEX; exit 3; }',
           'test ! -f "$OUTPUT_DIR/claude-code/test-analysis.md"   || { echo LEAK-CLAUDE; exit 3; }',
+          "# 非 managed（ユーザーファイル/別 task 残骸）は削除しない",
+          'test -f "$OUTPUT_DIR/codex-cli/my-notes.md"             || { echo USER-FILE-DELETED; exit 4; }',
+          'test -f "$OUTPUT_DIR/codex-cli/api-surface-analysis.md" || { echo NONMANAGED-DELETED; exit 4; }',
           'echo RUN2-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
           "generate_review_report >/dev/null 2>&1",
           'cat "$OUTPUT_DIR/integrated-report.md"',
@@ -212,6 +218,9 @@ describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
       // 1回目のみの stale（両 CLI）は含まれない ← 受け入れ基準
       expect(r.stdout).not.toContain("STALE-CODEX-SEC");
       expect(r.stdout).not.toContain("STALE-CLAUDE-TEST");
+      // 非 managed の残骸はレポートに載らない（バウンドされた収集）
+      expect(r.stdout).not.toContain("STALE-EXPLORE");
+      expect(r.stdout).not.toContain("USER-NOTES");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }
@@ -243,14 +252,17 @@ describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
     }
   });
 
-  it("空 OUTPUT_DIR ではガードが働き、削除ロジックに入らず正常終了する", () => {
+  it("空文字・未設定どちらの OUTPUT_DIR でもガードが働き削除ロジックに入らず正常終了する", () => {
     const workDir = mkdtempSync(join(tmpdir(), "ma-guard-"));
     try {
       const r = runHarness(
         [
           "TASK_TYPE=review",
-          "# OUTPUT_DIR が空なら rm 系ロジックへ進まず no-op で return 0",
+          "# 空文字ケース: rm 系ロジックへ進まず no-op で return 0",
           'OUTPUT_DIR=""',
+          "cleanup_stale_results",
+          "# 未設定ケース: set -u 下でも ${OUTPUT_DIR:-} ガードで unbound を踏まず return 0",
+          "unset OUTPUT_DIR",
           "cleanup_stale_results",
           "echo GUARD_OK",
         ],

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -153,123 +153,104 @@ describe("multi-agent.sh config loading (set -e regression)", () => {
   );
 });
 
-// 前回実行の stale 結果がレポートに混入しない回帰（issue #450）
-// end-to-end 実行はアダプタが実 CLI を叩くため、末尾の main を無効化して source し、
-// cleanup_stale_results / execute_tasks を直接検証する。実在の perspective 名を使う
-// （cleanup は当スクリプトが生成し得る perspective ファイルのみ削除するため）。
-describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
-  const SCRIPTS_DIR = join(REPO_ROOT, "scripts");
-
-  /** main を無効化した multi-agent.sh を temp に書き出しパスを返す */
+// レポートが「今回の実行分（EXECUTION_PLAN）」だけを収録し、前回実行の stale 結果を
+// 混入させない回帰（issue #450）。end-to-end 実行はアダプタが実 CLI を叩くため、末尾の
+// main を無効化して source し、generate_*_report を直接検証する。修正方針は「削除」ではなく
+// 「レポートを plan 駆動にする」= ディスク上のファイルは一切壊さず、プラン外は読まない。
+describe("multi-agent.sh plan-scoped report (issue #450)", () => {
+  /** main を無効化した multi-agent.sh を temp に書き出しパスを返す（置換不発なら loud fail） */
   function neutralizedScript(): string {
     const raw = readFileSync(SCRIPT, "utf8");
     const neutralized = raw.replace(/^main "\$@"$/m, "true");
+    if (neutralized === raw) {
+      throw new Error("neutralization failed: 末尾の 'main \"$@\"' が見つからない（呼び出し形が変わった可能性）");
+    }
     const file = join(stubDir, "multi-agent.neutralized.sh");
     writeFileSync(file, neutralized);
     return file;
   }
 
-  /**
-   * bash ハーネスを実行する。ハーネスは必ず `set -euo pipefail` で始め、source 直後に
-   * SCRIPT_DIR を実 scripts へ上書きする（$0 由来の推定では perspectives を解決できない）。
-   */
+  /** bash ハーネスを実行する。必ず `set -euo pipefail` で始める（途中失敗を握り潰さない）。 */
   function runHarness(body: string[], workDir: string) {
-    const harness = ["set -euo pipefail", 'source "$NEUT"', 'SCRIPT_DIR="$SCRIPTS_DIR"', ...body];
+    const harness = ["set -euo pipefail", 'source "$NEUT"', ...body];
     return spawnSync("bash", ["-c", harness.join("\n")], {
       encoding: "utf8",
       timeout: 30_000,
-      env: { ...process.env, NEUT: neutralizedScript(), SCRIPTS_DIR, WORKDIR: workDir },
+      env: { ...process.env, NEUT: neutralizedScript(), WORKDIR: workDir },
     });
   }
 
-  it("2回目の実行で、1回目のみに存在した perspective の結果がレポートに含まれない（マルチ CLI）", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-stale-"));
+  // 3 タスク種すべてで plan 駆動の収集ロジックを検証する（report builder は共通実装）。
+  const TASK_REPORTS = [
+    { type: "review", fn: "generate_review_report" },
+    { type: "explore", fn: "generate_explore_report" },
+    { type: "implement", fn: "generate_implement_report" },
+  ];
+
+  for (const { type, fn } of TASK_REPORTS) {
+    it(`${type}: レポートは EXECUTION_PLAN のエントリのみ収録し、プラン外の stale を混入させない`, () => {
+      const workDir = mkdtempSync(join(tmpdir(), `ma-${type}-`));
+      try {
+        const r = runHarness(
+          [
+            `MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; DESCRIPTION=test; TASK_TYPE=${type}`,
+            'OUTPUT_DIR="$WORKDIR/out"',
+            'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/claude-code"',
+            "# 今回のプラン分（codex-cli:alpha, claude-code:beta）",
+            'echo CURRENT-CODEX  > "$OUTPUT_DIR/codex-cli/alpha.md"',
+            'echo CURRENT-CLAUDE > "$OUTPUT_DIR/claude-code/beta.md"',
+            "# プラン外: 前回のみの stale と、ユーザー自身の Markdown",
+            'echo STALE-GAMMA > "$OUTPUT_DIR/codex-cli/gamma.md"',
+            'echo USER-NOTES  > "$OUTPUT_DIR/codex-cli/my-notes.md"',
+            "EXECUTION_PLAN=$'codex-cli:alpha\\nclaude-code:beta'",
+            `${fn} >/dev/null 2>&1`,
+            "# レポートは読むだけ — ディスク上のプラン外ファイルは消えない（非破壊）",
+            'test -f "$OUTPUT_DIR/codex-cli/gamma.md" && test -f "$OUTPUT_DIR/codex-cli/my-notes.md" && echo NONDESTRUCTIVE_OK',
+            'cat "$OUTPUT_DIR/integrated-report.md"',
+          ],
+          workDir,
+        );
+        expect(r.status).toBe(0);
+        // 今回のプラン分（マルチ CLI）は両方収録
+        expect(r.stdout).toContain("CURRENT-CODEX");
+        expect(r.stdout).toContain("CURRENT-CLAUDE");
+        // プラン外の stale / ユーザーファイルは収録されない ← 受け入れ基準
+        expect(r.stdout).not.toContain("STALE-GAMMA");
+        expect(r.stdout).not.toContain("USER-NOTES");
+        // 非破壊: ディスク上のファイルは削除されない
+        expect(r.stdout).toContain("NONDESTRUCTIVE_OK");
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    });
+  }
+
+  it("部分実行（--cli 相当）: 他 CLI の既存結果はレポート非収録だが、ディスク上は破壊しない", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-partial-"));
     try {
       const r = runHarness(
         [
           "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
-          'OUTPUT_DIR="$WORKDIR/.review-results"',
-          'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/claude-code"',
-          "# run 1: 実行された managed perspective（codex-cli / claude-code 跨ぎ）",
-          'echo STALE-CODEX-SEC   > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
-          'echo RUN1-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
-          'echo STALE-CLAUDE-TEST > "$OUTPUT_DIR/claude-code/test-analysis.md"',
-          "# 非 managed な残骸: 別 task type の perspective 結果とユーザー自身の Markdown",
-          'echo STALE-EXPLORE > "$OUTPUT_DIR/codex-cli/api-surface-analysis.md"',
-          'echo USER-NOTES    > "$OUTPUT_DIR/codex-cli/my-notes.md"',
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/gemini-cli"',
+          "# 前回は全 CLI 実行、今回は codex-cli のみ実行（部分実行）",
+          'echo OLD-GEMINI > "$OUTPUT_DIR/gemini-cli/code-review.md"',
+          'echo NEW-CODEX  > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          'EXECUTION_PLAN="codex-cli:code-review"',
           "generate_review_report >/dev/null 2>&1",
-          "# run 2: cleanup 後、codex-cli の code-review のみ実行",
-          "cleanup_stale_results",
-          "# managed stale は両 CLI 跨ぎで削除される（マルチ CLI 分離）",
-          'test ! -f "$OUTPUT_DIR/codex-cli/security-analysis.md" || { echo LEAK-CODEX; exit 3; }',
-          'test ! -f "$OUTPUT_DIR/claude-code/test-analysis.md"   || { echo LEAK-CLAUDE; exit 3; }',
-          "# 非 managed（ユーザーファイル/別 task 残骸）は削除しない",
-          'test -f "$OUTPUT_DIR/codex-cli/my-notes.md"             || { echo USER-FILE-DELETED; exit 4; }',
-          'test -f "$OUTPUT_DIR/codex-cli/api-surface-analysis.md" || { echo NONMANAGED-DELETED; exit 4; }',
-          'echo RUN2-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
-          "generate_review_report >/dev/null 2>&1",
+          "# gemini の既存結果はディスクに残る（破壊しない）",
+          'test -f "$OUTPUT_DIR/gemini-cli/code-review.md" && echo GEMINI-KEPT',
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
-      // 今回実行した code-review の最新結果は含まれる
-      expect(r.stdout).toContain("RUN2-CODEX-REVIEW");
-      // 1回目のみの stale（両 CLI）は含まれない ← 受け入れ基準
-      expect(r.stdout).not.toContain("STALE-CODEX-SEC");
-      expect(r.stdout).not.toContain("STALE-CLAUDE-TEST");
-      // 非 managed の残骸はレポートに載らない（バウンドされた収集）
-      expect(r.stdout).not.toContain("STALE-EXPLORE");
-      expect(r.stdout).not.toContain("USER-NOTES");
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("execute_tasks が実行時に cleanup_stale_results を走らせる（実行時の配線ガード）", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-wire-"));
-    try {
-      const r = runHarness(
-        [
-          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
-          'OUTPUT_DIR="$WORKDIR/.review-results"',
-          "# 実アダプタ/CLI 起動を防ぐため run_single_task を no-op 化",
-          "run_single_task() { return 0; }",
-          'mkdir -p "$OUTPUT_DIR/codex-cli"',
-          'echo STALE > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
-          "# 1 エントリのプランで execute_tasks を実行 → 内部で cleanup が走るはず",
-          'EXECUTION_PLAN="codex-cli:code-review"',
-          "execute_tasks >/dev/null 2>&1",
-          'test ! -f "$OUTPUT_DIR/codex-cli/security-analysis.md" && echo WIRED_OK || echo WIRING_BROKEN',
-        ],
-        workDir,
-      );
-      expect(r.status).toBe(0);
-      expect(r.stdout).toContain("WIRED_OK");
-      expect(r.stdout).not.toContain("WIRING_BROKEN");
-    } finally {
-      rmSync(workDir, { recursive: true, force: true });
-    }
-  });
-
-  it("空文字・未設定どちらの OUTPUT_DIR でもガードが働き削除ロジックに入らず正常終了する", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-guard-"));
-    try {
-      const r = runHarness(
-        [
-          "TASK_TYPE=review",
-          "# 空文字ケース: rm 系ロジックへ進まず no-op で return 0",
-          'OUTPUT_DIR=""',
-          "cleanup_stale_results",
-          "# 未設定ケース: set -u 下でも ${OUTPUT_DIR:-} ガードで unbound を踏まず return 0",
-          "unset OUTPUT_DIR",
-          "cleanup_stale_results",
-          "echo GUARD_OK",
-        ],
-        workDir,
-      );
-      expect(r.status).toBe(0);
-      expect(r.stdout).toContain("GUARD_OK");
+      // 今回分のみ収録
+      expect(r.stdout).toContain("NEW-CODEX");
+      // 今回プラン外の他 CLI 結果はレポートに載らない（今回分のみ）
+      expect(r.stdout).not.toContain("OLD-GEMINI");
+      // ただしディスク上は破壊されない（旧 cleanup 方式の破壊的挙動を回避）
+      expect(r.stdout).toContain("GEMINI-KEPT");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -151,4 +151,60 @@ describe("multi-agent.sh config loading (set -e regression)", () => {
       expect(r.output).toContain("Execution Plan");
     },
   );
+});
+
+// 前回実行の stale 結果がレポートに混入しない回帰（issue #450）
+// end-to-end 実行はアダプタが実 CLI を叩くため、末尾の main を無効化して source し、
+// cleanup_stale_results / generate_review_report を直接検証する。
+describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
+  /** main を無効化した multi-agent.sh を temp に書き出しパスを返す */
+  function neutralizedScript(): string {
+    const raw = readFileSync(SCRIPT, "utf8");
+    const neutralized = raw.replace(/^main "\$@"$/m, "true");
+    const file = join(stubDir, "multi-agent.neutralized.sh");
+    writeFileSync(file, neutralized);
+    return file;
+  }
+
+  it("2回目の実行で、1回目のみに存在した perspective の結果がレポートに含まれない", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-stale-"));
+    const harness = [
+      'set -uo pipefail',
+      'source "$NEUT"',
+      "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+      'OUTPUT_DIR="$WORKDIR/.review-results"',
+      'mkdir -p "$OUTPUT_DIR/codex-cli"',
+      "# run 1: security + performance を実行",
+      'echo STALE-SECURITY > "$OUTPUT_DIR/codex-cli/security.md"',
+      'echo RUN1-PERF > "$OUTPUT_DIR/codex-cli/performance.md"',
+      "generate_review_report >/dev/null 2>&1",
+      "# run 2: cleanup 後 performance のみ実行",
+      "cleanup_stale_results",
+      'echo RUN2-PERF > "$OUTPUT_DIR/codex-cli/performance.md"',
+      "generate_review_report >/dev/null 2>&1",
+      'cat "$OUTPUT_DIR/integrated-report.md"',
+    ].join("\n");
+
+    try {
+      const r = spawnSync("bash", ["-c", harness], {
+        encoding: "utf8",
+        timeout: 30_000,
+        env: { ...process.env, NEUT: neutralizedScript(), WORKDIR: workDir },
+      });
+      expect(r.status).toBe(0);
+      // 今回実行した performance の最新結果は含まれる
+      expect(r.stdout).toContain("RUN2-PERF");
+      // 1回目のみの security（stale）は含まれない ← 受け入れ基準
+      expect(r.stdout).not.toContain("STALE-SECURITY");
+      // 1回目の performance 本文も残らない（上書きされている）
+      expect(r.stdout).not.toContain("RUN1-PERF");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("execute_tasks が実行ループ前に cleanup_stale_results を呼ぶ（配線の回帰ガード）", () => {
+    const raw = readFileSync(SCRIPT, "utf8");
+    expect(raw).toMatch(/mkdir -p "\$OUTPUT_DIR"\s*\n\s*cleanup_stale_results/);
+  });
 });

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -158,12 +158,16 @@ describe("multi-agent.sh config loading (set -e regression)", () => {
 // main を無効化して source し、generate_*_report を直接検証する。修正方針は「削除」ではなく
 // 「レポートを plan 駆動にする」= ディスク上のファイルは一切壊さず、プラン外は読まない。
 describe("multi-agent.sh plan-scoped report (issue #450)", () => {
-  /** main を無効化した multi-agent.sh を temp に書き出しパスを返す（置換不発なら loud fail） */
+  /**
+   * main を無効化した multi-agent.sh を temp に書き出しパスを返す。呼び出し形の変化に
+   * 寛容にするため `main` で始まる行全体を対象にし（`main "$@"` / `main "$@" || exit`
+   * 等）、置換不発なら loud fail する（実装形変更を silent no-op で見逃さない）。
+   */
   function neutralizedScript(): string {
     const raw = readFileSync(SCRIPT, "utf8");
-    const neutralized = raw.replace(/^main "\$@"$/m, "true");
+    const neutralized = raw.replace(/^main(?:\s.*)?$/m, "true");
     if (neutralized === raw) {
-      throw new Error("neutralization failed: 末尾の 'main \"$@\"' が見つからない（呼び出し形が変わった可能性）");
+      throw new Error("neutralization failed: エントリポイント 'main ...' 行が見つからない（呼び出し形が変わった可能性）");
     }
     const file = join(stubDir, "multi-agent.neutralized.sh");
     writeFileSync(file, neutralized);
@@ -251,6 +255,58 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
       expect(r.stdout).not.toContain("OLD-GEMINI");
       // ただしディスク上は破壊されない（旧 cleanup 方式の破壊的挙動を回避）
       expect(r.stdout).toContain("GEMINI-KEPT");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("空プランでは (No ... results found.) に落ちる（境界条件）", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-empty-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR"',
+          '# ディスクに残骸があってもプランが空なら何も収録しない',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          'echo STALE > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          'EXECUTION_PLAN=""',
+          "generate_review_report >/dev/null 2>&1",
+          'cat "$OUTPUT_DIR/integrated-report.md"',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("(No review results found.)");
+      expect(r.stdout).not.toContain("STALE");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("プラン内エントリの出力が欠落しても黙って落とさずレポートに可視化する（silent-failure 回避）", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-missing-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          "# codex-cli:code-review は成功、gemini-cli:code-review は出力欠落（CLI 失敗相当）",
+          'echo OK-CODEX > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          "EXECUTION_PLAN=$'codex-cli:code-review\\ngemini-cli:code-review'",
+          "generate_review_report >/dev/null 2>&1",
+          'cat "$OUTPUT_DIR/integrated-report.md"',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      // 成功分は収録
+      expect(r.stdout).toContain("OK-CODEX");
+      // 欠落したエントリは見出しごと可視化される（黙殺しない）
+      expect(r.stdout).toContain("gemini-cli — code-review");
+      expect(r.stdout).toContain("No output produced by this task");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -155,8 +155,11 @@ describe("multi-agent.sh config loading (set -e regression)", () => {
 
 // 前回実行の stale 結果がレポートに混入しない回帰（issue #450）
 // end-to-end 実行はアダプタが実 CLI を叩くため、末尾の main を無効化して source し、
-// cleanup_stale_results / generate_review_report を直接検証する。
+// cleanup_stale_results / execute_tasks を直接検証する。実在の perspective 名を使う
+// （cleanup は当スクリプトが生成し得る perspective ファイルのみ削除するため）。
 describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
+  const SCRIPTS_DIR = join(REPO_ROOT, "scripts");
+
   /** main を無効化した multi-agent.sh を temp に書き出しパスを返す */
   function neutralizedScript(): string {
     const raw = readFileSync(SCRIPT, "utf8");
@@ -166,45 +169,97 @@ describe("multi-agent.sh stale-result cleanup (issue #450)", () => {
     return file;
   }
 
-  it("2回目の実行で、1回目のみに存在した perspective の結果がレポートに含まれない", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-stale-"));
-    const harness = [
-      'set -uo pipefail',
-      'source "$NEUT"',
-      "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
-      'OUTPUT_DIR="$WORKDIR/.review-results"',
-      'mkdir -p "$OUTPUT_DIR/codex-cli"',
-      "# run 1: security + performance を実行",
-      'echo STALE-SECURITY > "$OUTPUT_DIR/codex-cli/security.md"',
-      'echo RUN1-PERF > "$OUTPUT_DIR/codex-cli/performance.md"',
-      "generate_review_report >/dev/null 2>&1",
-      "# run 2: cleanup 後 performance のみ実行",
-      "cleanup_stale_results",
-      'echo RUN2-PERF > "$OUTPUT_DIR/codex-cli/performance.md"',
-      "generate_review_report >/dev/null 2>&1",
-      'cat "$OUTPUT_DIR/integrated-report.md"',
-    ].join("\n");
+  /**
+   * bash ハーネスを実行する。ハーネスは必ず `set -euo pipefail` で始め、source 直後に
+   * SCRIPT_DIR を実 scripts へ上書きする（$0 由来の推定では perspectives を解決できない）。
+   */
+  function runHarness(body: string[], workDir: string) {
+    const harness = ["set -euo pipefail", 'source "$NEUT"', 'SCRIPT_DIR="$SCRIPTS_DIR"', ...body];
+    return spawnSync("bash", ["-c", harness.join("\n")], {
+      encoding: "utf8",
+      timeout: 30_000,
+      env: { ...process.env, NEUT: neutralizedScript(), SCRIPTS_DIR, WORKDIR: workDir },
+    });
+  }
 
+  it("2回目の実行で、1回目のみに存在した perspective の結果がレポートに含まれない（マルチ CLI）", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-stale-"));
     try {
-      const r = spawnSync("bash", ["-c", harness], {
-        encoding: "utf8",
-        timeout: 30_000,
-        env: { ...process.env, NEUT: neutralizedScript(), WORKDIR: workDir },
-      });
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          'OUTPUT_DIR="$WORKDIR/.review-results"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/claude-code"',
+          "# run 1: codex-cli で security-analysis + code-review、claude-code で test-analysis",
+          'echo STALE-CODEX-SEC   > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
+          'echo RUN1-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          'echo STALE-CLAUDE-TEST > "$OUTPUT_DIR/claude-code/test-analysis.md"',
+          "generate_review_report >/dev/null 2>&1",
+          "# run 2: cleanup 後、codex-cli の code-review のみ実行",
+          "cleanup_stale_results",
+          "# 別 CLI に跨って stale が消えること（マルチ CLI 分離）",
+          'test ! -f "$OUTPUT_DIR/codex-cli/security-analysis.md" || { echo LEAK-CODEX; exit 3; }',
+          'test ! -f "$OUTPUT_DIR/claude-code/test-analysis.md"   || { echo LEAK-CLAUDE; exit 3; }',
+          'echo RUN2-CODEX-REVIEW > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          "generate_review_report >/dev/null 2>&1",
+          'cat "$OUTPUT_DIR/integrated-report.md"',
+        ],
+        workDir,
+      );
       expect(r.status).toBe(0);
-      // 今回実行した performance の最新結果は含まれる
-      expect(r.stdout).toContain("RUN2-PERF");
-      // 1回目のみの security（stale）は含まれない ← 受け入れ基準
-      expect(r.stdout).not.toContain("STALE-SECURITY");
-      // 1回目の performance 本文も残らない（上書きされている）
-      expect(r.stdout).not.toContain("RUN1-PERF");
+      // 今回実行した code-review の最新結果は含まれる
+      expect(r.stdout).toContain("RUN2-CODEX-REVIEW");
+      // 1回目のみの stale（両 CLI）は含まれない ← 受け入れ基準
+      expect(r.stdout).not.toContain("STALE-CODEX-SEC");
+      expect(r.stdout).not.toContain("STALE-CLAUDE-TEST");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }
   });
 
-  it("execute_tasks が実行ループ前に cleanup_stale_results を呼ぶ（配線の回帰ガード）", () => {
-    const raw = readFileSync(SCRIPT, "utf8");
-    expect(raw).toMatch(/mkdir -p "\$OUTPUT_DIR"\s*\n\s*cleanup_stale_results/);
+  it("execute_tasks が実行時に cleanup_stale_results を走らせる（実行時の配線ガード）", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-wire-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
+          'OUTPUT_DIR="$WORKDIR/.review-results"',
+          "# 実アダプタ/CLI 起動を防ぐため run_single_task を no-op 化",
+          "run_single_task() { return 0; }",
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          'echo STALE > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
+          "# 1 エントリのプランで execute_tasks を実行 → 内部で cleanup が走るはず",
+          'EXECUTION_PLAN="codex-cli:code-review"',
+          "execute_tasks >/dev/null 2>&1",
+          'test ! -f "$OUTPUT_DIR/codex-cli/security-analysis.md" && echo WIRED_OK || echo WIRING_BROKEN',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("WIRED_OK");
+      expect(r.stdout).not.toContain("WIRING_BROKEN");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("空 OUTPUT_DIR ではガードが働き、削除ロジックに入らず正常終了する", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-guard-"));
+    try {
+      const r = runHarness(
+        [
+          "TASK_TYPE=review",
+          "# OUTPUT_DIR が空なら rm 系ロジックへ進まず no-op で return 0",
+          'OUTPUT_DIR=""',
+          "cleanup_stale_results",
+          "echo GUARD_OK",
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("GUARD_OK");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -188,7 +188,7 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
 
   // 公開ディスパッチャ generate_report を TASK_TYPE で切り替えて 3 タスク種を検証する
   // （検証込みの実エントリポイント。builder 直呼びより実挙動に近い）。
-  const TASK_TYPES = ["review", "explore", "implement"];
+  const TASK_TYPES = ["review", "explore", "implement"] as const;
 
   // 境界条件（プラン外除外/非破壊・空プラン・欠落可視化）を 3 タスク種すべてで検証する。
   for (const type of TASK_TYPES) {
@@ -287,8 +287,8 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           'echo OLD-GEMINI > "$OUTPUT_DIR/gemini-cli/code-review.md"',
           'echo NEW-CODEX  > "$OUTPUT_DIR/codex-cli/code-review.md"',
           'EXECUTION_PLAN="codex-cli:code-review"',
-          "generate_review_report >/dev/null 2>&1",
-          'test -f "$OUTPUT_DIR/gemini-cli/code-review.md" && echo GEMINI-KEPT',
+          "generate_report >/dev/null 2>&1",
+          'if [[ -f "$OUTPUT_DIR/gemini-cli/code-review.md" ]]; then echo GEMINI-KEPT; fi',
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
@@ -314,14 +314,18 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           'echo STALE-PREV > "$OUTPUT_DIR/codex-cli/code-review.md"',
           "run_single_task() { return 1; }",
           'EXECUTION_PLAN="codex-cli:code-review"',
-          "# execute_tasks は失敗検知で非0（|| true）。事前クリアで stale ファイルは消える",
-          "execute_tasks >/dev/null 2>&1 || true",
+          "# execute_tasks は task 失敗を検知して非0（握り潰さず rc を明示検証）。",
+          '# 事前クリアで stale ファイルは消える。想定外の rc はテストで検出する。',
+          'rc_exec=0; execute_tasks >/dev/null 2>&1 || rc_exec=$?',
+          'echo "rc_exec=$rc_exec"',
           "generate_report >/dev/null 2>&1",
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
+      // run_single_task 失敗により execute_tasks は非0（task 失敗）で返る（設定不備等の別要因ではない）
+      expect(r.stdout).toContain("rc_exec=1");
       // 前回の同名 stale は current として混入しない
       expect(r.stdout).not.toContain("STALE-PREV");
       // 代わりに欠落として可視化される
@@ -368,6 +372,97 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
       expect(r.stdout).toContain("REP_LOUD");
       expect(r.stdout).toContain("NO_LEAK");
       expect(r.stdout).not.toContain("TOP-SECRET");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("不正な EXECUTION_PLAN（区切り ':' 無し・'.'・'..'）は generate_report で fail-loud に拒否される", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-malformed-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          "check() { # $1=plan $2=ラベル",
+          '  local rc=0; EXECUTION_PLAN="$1" generate_report >/dev/null 2>"$WORKDIR/e.txt" || rc=$?',
+          '  if [[ "$rc" -ne 0 ]] && grep -qiE "unsafe|malformed" "$WORKDIR/e.txt"; then echo "$2:LOUD"; else echo "$2:PASSED-THROUGH"; fi',
+          "}",
+          '# ":" 無し（cli_name と persp_name が同値になる不正形）',
+          'check "codex-cli" NOCOLON',
+          '# perspective が ".." （traversal 境界）',
+          'check "codex-cli:.." DOTDOT',
+          '# cli_name が "." （境界）',
+          'check ".:code-review" DOT',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("NOCOLON:LOUD");
+      expect(r.stdout).toContain("DOTDOT:LOUD");
+      expect(r.stdout).toContain("DOT:LOUD");
+      expect(r.stdout).not.toContain("PASSED-THROUGH");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clear_planned_outputs は execute_tasks 経由でプラン外（他 CLI/他 perspective/ユーザー .md）を消さない", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-clearscope-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli" "$OUTPUT_DIR/gemini-cli"',
+          "# プラン対象（今回クリア＆再生成される）",
+          'echo PREV > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          "# プラン外: 他 CLI / 同 CLI 別 perspective / ユーザーファイル",
+          'echo KEEP-GEMINI  > "$OUTPUT_DIR/gemini-cli/code-review.md"',
+          'echo KEEP-OTHERP  > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
+          'echo KEEP-USER    > "$OUTPUT_DIR/codex-cli/my-notes.md"',
+          "run_single_task() { return 0; }",
+          'EXECUTION_PLAN="codex-cli:code-review"',
+          "execute_tasks >/dev/null 2>&1 || true",
+          '# プラン対象だけがクリアされ、他は温存される',
+          'if [[ ! -f "$OUTPUT_DIR/codex-cli/code-review.md" ]]; then echo TARGET_CLEARED; fi',
+          'if [[ -f "$OUTPUT_DIR/gemini-cli/code-review.md" ]]; then echo GEMINI_KEPT; fi',
+          'if [[ -f "$OUTPUT_DIR/codex-cli/security-analysis.md" ]]; then echo OTHERP_KEPT; fi',
+          'if [[ -f "$OUTPUT_DIR/codex-cli/my-notes.md" ]]; then echo USER_KEPT; fi',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("TARGET_CLEARED");
+      expect(r.stdout).toContain("GEMINI_KEPT");
+      expect(r.stdout).toContain("OTHERP_KEPT");
+      expect(r.stdout).toContain("USER_KEPT");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("プラン内の重複 cli:perspective はレポートに二重掲載されない", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-dup-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          'echo DUP-CONTENT > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          "# 同じエントリを重複させる",
+          "EXECUTION_PLAN=$'codex-cli:code-review\\ncodex-cli:code-review'",
+          "generate_report >/dev/null 2>&1",
+          '# 見出しの出現回数を数える',
+          'grep -c "^## codex-cli — code-review " "$OUTPUT_DIR/integrated-report.md" | sed "s/^/HEADING_COUNT=/"',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      // 重複エントリでも見出しは 1 回だけ
+      expect(r.stdout).toContain("HEADING_COUNT=1");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -154,9 +154,11 @@ describe("multi-agent.sh config loading (set -e regression)", () => {
 });
 
 // レポートが「今回の実行分（EXECUTION_PLAN）」だけを収録し、前回実行の stale 結果を
-// 混入させない回帰（issue #450）。end-to-end 実行はアダプタが実 CLI を叩くため、末尾の
-// main を無効化して source し、generate_*_report を直接検証する。修正方針は「削除」ではなく
-// 「レポートを plan 駆動にする」= ディスク上のファイルは一切壊さず、プラン外は読まない。
+// 混入させない回帰（issue #450）。アダプタが実 CLI を叩くため末尾の main を無効化して
+// source し、generate_report / execute_tasks を直接検証する。方針: レポートは plan 駆動で
+// 収集し、実行前に「プランの自分の出力先だけ」を rm する（他 CLI/他 perspective/ユーザー
+// ファイルは非破壊）。不正な cli/perspective トークンは validate_execution_plan で
+// fail-loud に拒否し、write/clear/read のどの経路でも OUTPUT_DIR 外へ出さない。
 describe("multi-agent.sh plan-scoped report (issue #450)", () => {
   /**
    * main を無効化した multi-agent.sh を temp に書き出しパスを返す。呼び出し形の変化に
@@ -184,15 +186,12 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
     });
   }
 
-  // 3 タスク種すべてで plan 駆動の収集ロジックを検証する（report builder は共通実装）。
-  const TASK_REPORTS = [
-    { type: "review", fn: "generate_review_report" },
-    { type: "explore", fn: "generate_explore_report" },
-    { type: "implement", fn: "generate_implement_report" },
-  ];
+  // 公開ディスパッチャ generate_report を TASK_TYPE で切り替えて 3 タスク種を検証する
+  // （検証込みの実エントリポイント。builder 直呼びより実挙動に近い）。
+  const TASK_TYPES = ["review", "explore", "implement"];
 
   // 境界条件（プラン外除外/非破壊・空プラン・欠落可視化）を 3 タスク種すべてで検証する。
-  for (const { type, fn } of TASK_REPORTS) {
+  for (const type of TASK_TYPES) {
     it(`${type}: レポートは EXECUTION_PLAN のエントリのみ収録し、プラン外の stale/ユーザーファイルを混入させない（非破壊）`, () => {
       const workDir = mkdtempSync(join(tmpdir(), `ma-${type}-`));
       try {
@@ -208,7 +207,7 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
             'echo STALE-GAMMA > "$OUTPUT_DIR/codex-cli/gamma.md"',
             'echo USER-NOTES  > "$OUTPUT_DIR/codex-cli/my-notes.md"',
             "EXECUTION_PLAN=$'codex-cli:alpha\\nclaude-code:beta'",
-            `${fn} >/dev/null 2>&1`,
+            "generate_report >/dev/null 2>&1",
             "# レポートは読むだけ — ディスク上のプラン外ファイルは消えない（非破壊）",
             'test -f "$OUTPUT_DIR/codex-cli/gamma.md" && test -f "$OUTPUT_DIR/codex-cli/my-notes.md" && echo NONDESTRUCTIVE_OK',
             'cat "$OUTPUT_DIR/integrated-report.md"',
@@ -237,7 +236,7 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
             "# ディスクに残骸があってもプランが空なら何も収録しない",
             'echo STALE > "$OUTPUT_DIR/codex-cli/alpha.md"',
             'EXECUTION_PLAN=""',
-            `${fn} >/dev/null 2>&1`,
+            "generate_report >/dev/null 2>&1",
             'cat "$OUTPUT_DIR/integrated-report.md"',
           ],
           workDir,
@@ -261,7 +260,7 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
             "# codex-cli:alpha は成功、gemini-cli:alpha は出力欠落（CLI 失敗相当）",
             'echo OK-CODEX > "$OUTPUT_DIR/codex-cli/alpha.md"',
             "EXECUTION_PLAN=$'codex-cli:alpha\\ngemini-cli:alpha'",
-            `${fn} >/dev/null 2>&1`,
+            "generate_report >/dev/null 2>&1",
             'cat "$OUTPUT_DIR/integrated-report.md"',
           ],
           workDir,
@@ -317,7 +316,7 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           'EXECUTION_PLAN="codex-cli:code-review"',
           "# execute_tasks は失敗検知で非0（|| true）。事前クリアで stale ファイルは消える",
           "execute_tasks >/dev/null 2>&1 || true",
-          "generate_review_report >/dev/null 2>&1",
+          "generate_report >/dev/null 2>&1",
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
@@ -332,27 +331,43 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
     }
   });
 
-  it("パストラバーサルな perspective/cli 名は OUTPUT_DIR 外を読まない", () => {
+  it("パストラバーサルな cli/perspective 名は fail-loud で拒否され、OUTPUT_DIR 外を読み書きしない", () => {
     const workDir = mkdtempSync(join(tmpdir(), "ma-traversal-"));
     try {
       const r = runHarness(
         [
-          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
           'OUTPUT_DIR="$WORKDIR/out"',
           'mkdir -p "$OUTPUT_DIR/codex-cli" "$WORKDIR/secretdir"',
-          "# OUTPUT_DIR の外に秘密ファイル。traversal で読めてしまわないことを確認",
           'echo TOP-SECRET > "$WORKDIR/secretdir/secret.md"',
-          "# $OUTPUT_DIR/codex-cli/../../secretdir/secret.md == $WORKDIR/secretdir/secret.md",
+          "run_single_task() { echo RAN-TASK >&2; return 0; }",
+          "# $OUTPUT_DIR/codex-cli/../../secretdir/secret(.md) == $WORKDIR/secretdir/secret.md",
           'EXECUTION_PLAN="codex-cli:../../secretdir/secret"',
-          "generate_review_report >/dev/null 2>&1",
-          'cat "$OUTPUT_DIR/integrated-report.md"',
+          "# 1) execute_tasks（write/clear 経路）は検証で fail-loud し、clear/run へ進まない",
+          'rc_exec=0; execute_tasks >/dev/null 2>"$WORKDIR/exec_err.txt" || rc_exec=$?',
+          'echo "rc_exec=$rc_exec"',
+          'if grep -q "unsafe token" "$WORKDIR/exec_err.txt"; then echo EXEC_LOUD; fi',
+          'if grep -q "RAN-TASK" "$WORKDIR/exec_err.txt"; then echo TASK_RAN; else echo TASK_NOT_RAN; fi',
+          'if [[ -f "$WORKDIR/secretdir/secret.md" ]]; then echo SECRET_KEPT; else echo SECRET_DELETED; fi',
+          "# 2) generate_report（read 経路）も fail-loud し、秘密を読まない",
+          'rc_rep=0; generate_report >/dev/null 2>"$WORKDIR/rep_err.txt" || rc_rep=$?',
+          'echo "rc_rep=$rc_rep"',
+          'if grep -q "unsafe token" "$WORKDIR/rep_err.txt"; then echo REP_LOUD; fi',
+          'if [[ -f "$OUTPUT_DIR/integrated-report.md" ]] && grep -q TOP-SECRET "$OUTPUT_DIR/integrated-report.md"; then echo SECRET_LEAKED; else echo NO_LEAK; fi',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
-      // ガードにより不正セグメントはスキップ → 秘密は読まれない
+      // execute_tasks: 非0 で fail-loud、run_single_task 未実行、外部 secret は削除されない
+      expect(r.stdout).toContain("rc_exec=1");
+      expect(r.stdout).toContain("EXEC_LOUD");
+      expect(r.stdout).toContain("TASK_NOT_RAN");
+      expect(r.stdout).toContain("SECRET_KEPT");
+      // generate_report: 非0 で fail-loud、秘密はレポートに漏れない
+      expect(r.stdout).toContain("rc_rep=1");
+      expect(r.stdout).toContain("REP_LOUD");
+      expect(r.stdout).toContain("NO_LEAK");
       expect(r.stdout).not.toContain("TOP-SECRET");
-      expect(r.stdout).toContain("(No review results found.)");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -526,4 +526,36 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
       rmSync(workDir, { recursive: true, force: true });
     }
   });
+
+  it("並列実行（PARALLEL=true）でも出力欠落は失敗として表面化する（並列経路の回帰）", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-parallel-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=true",
+          "# case A: 成功して出力を書く → wait 分岐は成功（rc=0）",
+          'OUTPUT_DIR="$WORKDIR/ok"; mkdir -p "$OUTPUT_DIR/codex-cli"',
+          'run_single_task() { echo out > "$OUTPUT_DIR/$1/$2.md"; return 0; }',
+          'EXECUTION_PLAN="codex-cli:code-review"',
+          'rc_ok=0; execute_tasks >/dev/null 2>&1 || rc_ok=$?',
+          'echo "rc_ok=$rc_ok"',
+          "# case B: 成功終了だが出力を書かない → wait 分岐で失敗扱い（rc=1）",
+          'OUTPUT_DIR="$WORKDIR/bad"; mkdir -p "$OUTPUT_DIR/codex-cli"',
+          "run_single_task() { return 0; }",
+          'rc_bad=0; execute_tasks >/dev/null 2>"$WORKDIR/e.txt" || rc_bad=$?',
+          'echo "rc_bad=$rc_bad"',
+          'if grep -q "No output file" "$WORKDIR/e.txt"; then echo REPORTED; fi',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      // 並列・出力あり → 成功
+      expect(r.stdout).toContain("rc_ok=0");
+      // 並列・出力欠落 → 非0 で表面化
+      expect(r.stdout).toContain("rc_bad=1");
+      expect(r.stdout).toContain("REPORTED");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -422,11 +422,15 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           'echo KEEP-GEMINI  > "$OUTPUT_DIR/gemini-cli/code-review.md"',
           'echo KEEP-OTHERP  > "$OUTPUT_DIR/codex-cli/security-analysis.md"',
           'echo KEEP-USER    > "$OUTPUT_DIR/codex-cli/my-notes.md"',
-          "run_single_task() { return 0; }",
+          "# タスクは成功して出力を書く（clear→再生成）",
+          'run_single_task() { echo FRESH > "$OUTPUT_DIR/codex-cli/code-review.md"; return 0; }',
           'EXECUTION_PLAN="codex-cli:code-review"',
-          "execute_tasks >/dev/null 2>&1 || true",
-          '# プラン対象だけがクリアされ、他は温存される',
-          'if [[ ! -f "$OUTPUT_DIR/codex-cli/code-review.md" ]]; then echo TARGET_CLEARED; fi',
+          'rc=0; execute_tasks >/dev/null 2>&1 || rc=$?',
+          'echo "rc=$rc"',
+          '# プラン対象は clear→再生成で FRESH（前回 PREV は残らない）',
+          'if grep -q FRESH "$OUTPUT_DIR/codex-cli/code-review.md"; then echo TARGET_FRESH; fi',
+          'if grep -q PREV "$OUTPUT_DIR/codex-cli/code-review.md"; then echo TARGET_STALE; else echo NO_STALE; fi',
+          '# プラン外は温存（他 CLI / 同 CLI 別 perspective / ユーザーファイル）',
           'if [[ -f "$OUTPUT_DIR/gemini-cli/code-review.md" ]]; then echo GEMINI_KEPT; fi',
           'if [[ -f "$OUTPUT_DIR/codex-cli/security-analysis.md" ]]; then echo OTHERP_KEPT; fi',
           'if [[ -f "$OUTPUT_DIR/codex-cli/my-notes.md" ]]; then echo USER_KEPT; fi',
@@ -434,7 +438,10 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
         workDir,
       );
       expect(r.status).toBe(0);
-      expect(r.stdout).toContain("TARGET_CLEARED");
+      // 出力を書く成功タスクなので execute_tasks は 0（握り潰さず検証）
+      expect(r.stdout).toContain("rc=0");
+      expect(r.stdout).toContain("TARGET_FRESH");
+      expect(r.stdout).toContain("NO_STALE");
       expect(r.stdout).toContain("GEMINI_KEPT");
       expect(r.stdout).toContain("OTHERP_KEPT");
       expect(r.stdout).toContain("USER_KEPT");
@@ -463,6 +470,58 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
       expect(r.status).toBe(0);
       // 重複エントリでも見出しは 1 回だけ
       expect(r.stdout).toContain("HEADING_COUNT=1");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("プラン内の重複 cli:perspective は実行時も 1 回だけ走る", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-dupexec-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          '# run_single_task の呼び出し回数を記録しつつ出力を書く',
+          'run_single_task() { echo x >> "$WORKDIR/calls.txt"; echo out > "$OUTPUT_DIR/$1/$2.md"; return 0; }',
+          "EXECUTION_PLAN=$'codex-cli:code-review\\ncodex-cli:code-review'",
+          'rc=0; execute_tasks >/dev/null 2>&1 || rc=$?',
+          'echo "rc=$rc"',
+          'echo "CALLS=$(wc -l < "$WORKDIR/calls.txt" | tr -d " ")"',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("rc=0");
+      // 重複は排除され実行は 1 回のみ
+      expect(r.stdout).toContain("CALLS=1");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("成功終了でも出力ファイルが無ければ execute_tasks は失敗（非0）で表面化する", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-nooutput-"));
+    try {
+      const r = runHarness(
+        [
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
+          'OUTPUT_DIR="$WORKDIR/out"',
+          'mkdir -p "$OUTPUT_DIR/codex-cli"',
+          "# アダプタが 0 を返すが出力を書かない（silent no-output）を模擬",
+          "run_single_task() { return 0; }",
+          'EXECUTION_PLAN="codex-cli:code-review"',
+          'rc=0; execute_tasks >/dev/null 2>"$WORKDIR/e.txt" || rc=$?',
+          'echo "rc=$rc"',
+          'if grep -q "No output file" "$WORKDIR/e.txt"; then echo REPORTED; fi',
+        ],
+        workDir,
+      );
+      expect(r.status).toBe(0);
+      // 出力欠落は exit code に反映される（silent 成功にならない）
+      expect(r.stdout).toContain("rc=1");
+      expect(r.stdout).toContain("REPORTED");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -191,8 +191,9 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
     { type: "implement", fn: "generate_implement_report" },
   ];
 
+  // 境界条件（プラン外除外/非破壊・空プラン・欠落可視化）を 3 タスク種すべてで検証する。
   for (const { type, fn } of TASK_REPORTS) {
-    it(`${type}: レポートは EXECUTION_PLAN のエントリのみ収録し、プラン外の stale を混入させない`, () => {
+    it(`${type}: レポートは EXECUTION_PLAN のエントリのみ収録し、プラン外の stale/ユーザーファイルを混入させない（非破壊）`, () => {
       const workDir = mkdtempSync(join(tmpdir(), `ma-${type}-`));
       try {
         const r = runHarness(
@@ -215,14 +216,60 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           workDir,
         );
         expect(r.status).toBe(0);
-        // 今回のプラン分（マルチ CLI）は両方収録
         expect(r.stdout).toContain("CURRENT-CODEX");
         expect(r.stdout).toContain("CURRENT-CLAUDE");
-        // プラン外の stale / ユーザーファイルは収録されない ← 受け入れ基準
         expect(r.stdout).not.toContain("STALE-GAMMA");
         expect(r.stdout).not.toContain("USER-NOTES");
-        // 非破壊: ディスク上のファイルは削除されない
         expect(r.stdout).toContain("NONDESTRUCTIVE_OK");
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${type}: 空プランでは (No ${type} results found.) に落ちる`, () => {
+      const workDir = mkdtempSync(join(tmpdir(), `ma-empty-${type}-`));
+      try {
+        const r = runHarness(
+          [
+            `MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; DESCRIPTION=test; TASK_TYPE=${type}`,
+            'OUTPUT_DIR="$WORKDIR/out"',
+            'mkdir -p "$OUTPUT_DIR/codex-cli"',
+            "# ディスクに残骸があってもプランが空なら何も収録しない",
+            'echo STALE > "$OUTPUT_DIR/codex-cli/alpha.md"',
+            'EXECUTION_PLAN=""',
+            `${fn} >/dev/null 2>&1`,
+            'cat "$OUTPUT_DIR/integrated-report.md"',
+          ],
+          workDir,
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain(`(No ${type} results found.)`);
+        expect(r.stdout).not.toContain("STALE");
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${type}: プラン内エントリの出力欠落を黙殺せずレポートに可視化する`, () => {
+      const workDir = mkdtempSync(join(tmpdir(), `ma-missing-${type}-`));
+      try {
+        const r = runHarness(
+          [
+            `MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; DESCRIPTION=test; TASK_TYPE=${type}`,
+            'OUTPUT_DIR="$WORKDIR/out"',
+            'mkdir -p "$OUTPUT_DIR/codex-cli"',
+            "# codex-cli:alpha は成功、gemini-cli:alpha は出力欠落（CLI 失敗相当）",
+            'echo OK-CODEX > "$OUTPUT_DIR/codex-cli/alpha.md"',
+            "EXECUTION_PLAN=$'codex-cli:alpha\\ngemini-cli:alpha'",
+            `${fn} >/dev/null 2>&1`,
+            'cat "$OUTPUT_DIR/integrated-report.md"',
+          ],
+          workDir,
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain("OK-CODEX");
+        expect(r.stdout).toContain("gemini-cli — alpha");
+        expect(r.stdout).toContain("No output produced by this task");
       } finally {
         rmSync(workDir, { recursive: true, force: true });
       }
@@ -242,71 +289,70 @@ describe("multi-agent.sh plan-scoped report (issue #450)", () => {
           'echo NEW-CODEX  > "$OUTPUT_DIR/codex-cli/code-review.md"',
           'EXECUTION_PLAN="codex-cli:code-review"',
           "generate_review_report >/dev/null 2>&1",
-          "# gemini の既存結果はディスクに残る（破壊しない）",
           'test -f "$OUTPUT_DIR/gemini-cli/code-review.md" && echo GEMINI-KEPT',
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
-      // 今回分のみ収録
       expect(r.stdout).toContain("NEW-CODEX");
-      // 今回プラン外の他 CLI 結果はレポートに載らない（今回分のみ）
       expect(r.stdout).not.toContain("OLD-GEMINI");
-      // ただしディスク上は破壊されない（旧 cleanup 方式の破壊的挙動を回避）
       expect(r.stdout).toContain("GEMINI-KEPT");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }
   });
 
-  it("空プランでは (No ... results found.) に落ちる（境界条件）", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-empty-"));
+  it("同名 cli/perspective の前回 stale は execute_tasks の事前クリアで混入せず、欠落として可視化される", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-samepath-"));
     try {
       const r = runHarness(
         [
-          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
+          "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review; PARALLEL=false",
           'OUTPUT_DIR="$WORKDIR/out"',
-          'mkdir -p "$OUTPUT_DIR"',
-          '# ディスクに残骸があってもプランが空なら何も収録しない',
           'mkdir -p "$OUTPUT_DIR/codex-cli"',
-          'echo STALE > "$OUTPUT_DIR/codex-cli/code-review.md"',
-          'EXECUTION_PLAN=""',
+          "# 前回の同名 stale。今回 CLI は失敗して上書きしない（run_single_task 失敗で模擬）",
+          'echo STALE-PREV > "$OUTPUT_DIR/codex-cli/code-review.md"',
+          "run_single_task() { return 1; }",
+          'EXECUTION_PLAN="codex-cli:code-review"',
+          "# execute_tasks は失敗検知で非0（|| true）。事前クリアで stale ファイルは消える",
+          "execute_tasks >/dev/null 2>&1 || true",
           "generate_review_report >/dev/null 2>&1",
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
-      expect(r.stdout).toContain("(No review results found.)");
-      expect(r.stdout).not.toContain("STALE");
+      // 前回の同名 stale は current として混入しない
+      expect(r.stdout).not.toContain("STALE-PREV");
+      // 代わりに欠落として可視化される
+      expect(r.stdout).toContain("No output produced by this task");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }
   });
 
-  it("プラン内エントリの出力が欠落しても黙って落とさずレポートに可視化する（silent-failure 回避）", () => {
-    const workDir = mkdtempSync(join(tmpdir(), "ma-missing-"));
+  it("パストラバーサルな perspective/cli 名は OUTPUT_DIR 外を読まない", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "ma-traversal-"));
     try {
       const r = runHarness(
         [
           "MODE=cross-model; STRATEGY=balanced; BASE_BRANCH=develop; TASK_TYPE=review",
           'OUTPUT_DIR="$WORKDIR/out"',
-          'mkdir -p "$OUTPUT_DIR/codex-cli"',
-          "# codex-cli:code-review は成功、gemini-cli:code-review は出力欠落（CLI 失敗相当）",
-          'echo OK-CODEX > "$OUTPUT_DIR/codex-cli/code-review.md"',
-          "EXECUTION_PLAN=$'codex-cli:code-review\\ngemini-cli:code-review'",
+          'mkdir -p "$OUTPUT_DIR/codex-cli" "$WORKDIR/secretdir"',
+          "# OUTPUT_DIR の外に秘密ファイル。traversal で読めてしまわないことを確認",
+          'echo TOP-SECRET > "$WORKDIR/secretdir/secret.md"',
+          "# $OUTPUT_DIR/codex-cli/../../secretdir/secret.md == $WORKDIR/secretdir/secret.md",
+          'EXECUTION_PLAN="codex-cli:../../secretdir/secret"',
           "generate_review_report >/dev/null 2>&1",
           'cat "$OUTPUT_DIR/integrated-report.md"',
         ],
         workDir,
       );
       expect(r.status).toBe(0);
-      // 成功分は収録
-      expect(r.stdout).toContain("OK-CODEX");
-      // 欠落したエントリは見出しごと可視化される（黙殺しない）
-      expect(r.stdout).toContain("gemini-cli — code-review");
-      expect(r.stdout).toContain("No output produced by this task");
+      // ガードにより不正セグメントはスキップ → 秘密は読まれない
+      expect(r.stdout).not.toContain("TOP-SECRET");
+      expect(r.stdout).toContain("(No review results found.)");
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Closes #450

## 問題

`generate_{review,explore,implement}_report` は `${OUTPUT_DIR}/${cli}/*.md` を**無条件に glob 収集**していた。書き込みは perspective 単位の上書きなので、前回だけ実行した perspective のファイルが残り続け、今回の `integrated-report.md` に「今回の結果」として混入する（PR #449 の silent-failure-hunter 検出）。

## 修正（設計）

クロスモデルレビュー（Codex）を通じて「削除で stale を消す」方式は**消しすぎ（ユーザーファイル破壊）vs 残しすぎ（stale 残留）のジレンマ**に陥ることが判明したため、**レポートを EXECUTION_PLAN 駆動**に転換した。

- **レポートは「今回実行したエントリ（EXECUTION_PLAN）」だけを収集**（glob 廃止）。プラン外の perspective は原理的に読まれない。
- **同名 perspective の stale 対策**として、実行前に「プランの自分の出力先だけ」を `clear_planned_outputs` で削除（他 CLI・他 perspective・ユーザーファイルには非破壊）。CLI 失敗で出力が無い場合はレポートに「⚠️ No output produced」と可視化。
- **入力検証を集中化**：`validate_execution_plan` が `cli:perspective` の形式＋パストラバーサル（`../` 等）を実行前に fail-loud で拒否（write/clear/read 全経路を OUTPUT_DIR 内に封じる）。
- **重複エントリの排除**（実行・レポート両方）と、**成功終了でも出力ファイルが無いタスクを失敗として exit code に反映**。

## テスト

`scripts/multi-agent.test.ts` に plan 駆動の回帰テストを追加（`quality:local` / CI で実行）:

- review/explore/implement 3タスク種で、レポートがプラン分のみ収録・プラン外 stale/ユーザーファイル非収録・非破壊
- 空プラン→`(No ... results found.)` 境界、欠落出力の可視化
- 部分実行（--cli 相当）の非破壊、同名 stale の事前クリア
- パストラバーサル/不正形式（`:` 無し・`.`・`..`）の fail-loud 拒否＋外部ファイル非削除・非漏洩
- 重複エントリの非二重実行・非二重掲載、出力欠落の exit code 反映（直列・並列）

各修正はミューテーションテストで検知力を確認。`quality:local` 100% / 140 tests green。

## レビュー

Toolkit（一次）+ Codex クロスモデルレビューを実施。Codex の指摘（破壊性・silent failure・traversal・重複・境界網羅等）に沿って設計を反復改善し、最終的に Codex 主要4観点（code-reviewer / silent-failure-hunter / type-design-analyzer / comment-analyzer）が PASS。

## Test（Issue の受け入れ基準）

- [x] 2回連続実行で、1回目のみに存在した perspective の結果が2回目のレポートに含まれないこと