### PR TITLE
fix: #451 multi-agent.sh の未使用デッドフラグ --delegate-toolkit を削除

### DIFF
--- a/docs-template/05-operations/deployment/multi-cli-review-orchestration.md
+++ b/docs-template/05-operations/deployment/multi-cli-review-orchestration.md
@@ -201,14 +201,6 @@ fallback:
   copilot-cli: codex-cli
   gemini-cli: codex-cli
   cursor-cli: codex-cli
-
-toolkit_delegation:
-  code-reviewer: codex-cli
-  silent-failure-hunter: codex-cli
-  type-design-analyzer: claude-code
-  pr-test-analyzer: codex-cli
-  comment-analyzer: gemini-cli
-  code-simplifier: cursor-cli
 ```
 
 ### Step 3: 動作確認
@@ -378,9 +370,6 @@ bash scripts/multi-review.sh --cli claude-code --cli codex-cli
 
 # セキュリティ分析だけ
 bash scripts/multi-review.sh --perspective security-analysis
-
-# pr-review-toolkit 移譲モード
-bash scripts/multi-review.sh --delegate-toolkit
 ```
 
 ### 結果の確認

--- a/docs-template/06-reference/REVIEW_AGENT_CREATION_GUIDE.md
+++ b/docs-template/06-reference/REVIEW_AGENT_CREATION_GUIDE.md
@@ -105,7 +105,7 @@
 
 ### Claude Code pr-review-toolkit との対応
 
-| Perspective          | pr-review-toolkit サブエージェント | 移譲先CLI           |
+| Perspective          | pr-review-toolkit サブエージェント | 担当CLI             |
 | -------------------- | ---------------------------------- | ------------------- |
 | Code Review          | code-reviewer                      | Codex CLI           |
 | Error Handler Hunt   | silent-failure-hunter              | Codex CLI           |
@@ -402,21 +402,6 @@ Output in the standard review format."
 | **minimize_cost**    | 固定料金/無料CLIを優先               | 予算制約がある場合       |
 | **maximize_quality** | 最も高品質なCLIに多く割当            | リリース前の最終レビュー |
 
-### Toolkit移譲パターン
-
-Claude Code の `pr-review-toolkit` サブエージェントを外部CLIに移譲し、Claudeのトークン消費を削減します：
-
-```yaml
-# 移譲マッピング
-toolkit_delegation:
-  code-reviewer: codex-cli # GPT系の別視点でレビュー
-  silent-failure-hunter: codex-cli # エラーハンドリングもCodexへ
-  type-design-analyzer: claude-code # 型設計はClaudeが最強（据置）
-  pr-test-analyzer: codex-cli # テスト分析もCodex（クロスモデル）
-  comment-analyzer: gemini-cli # コメント分析はGemini（無料枠）
-  code-simplifier: cursor-cli # コード簡素化はCursor
-```
-
 ### Graceful Degradation（フォールバック）
 
 CLIが未インストールの場合、パースペクティブを他のCLIに再分配します：
@@ -446,7 +431,7 @@ fallback:
 | 呼び出し元      | 方法             | 例                                                             |
 | --------------- | ---------------- | -------------------------------------------------------------- |
 | **ターミナル**  | 直接実行         | `bash scripts/multi-review.sh`                                 |
-| **Claude Code** | Bash tool / hook | `bash scripts/multi-review.sh --delegate-toolkit`              |
+| **Claude Code** | Bash tool / hook | `bash scripts/multi-review.sh`                                 |
 | **Copilot CLI** | プロンプト経由   | `copilot -p "bash scripts/multi-review.sh を実行して"`         |
 | **CI/CD**       | GitHub Actions   | `- run: bash scripts/multi-review.sh --strategy minimize_cost` |
 | **Husky**       | pre-push hook    | `.husky/pre-push` から呼び出し                                 |
@@ -463,7 +448,6 @@ bash scripts/multi-review.sh [options]
   --parallel              並列実行（デフォルト）
   --sequential            順次実行
   --output-dir <dir>      出力先（デフォルト: .review-results/）
-  --delegate-toolkit      pr-review-toolkitのパースペクティブを外部CLIに移譲
 ```
 
 ### 使用例
@@ -477,9 +461,6 @@ bash scripts/multi-review.sh --strategy minimize_cost
 
 # 特定CLIのみ（標準の2本柱）
 bash scripts/multi-review.sh --cli claude-code --cli codex-cli
-
-# pr-review-toolkit移譲モード
-bash scripts/multi-review.sh --delegate-toolkit
 
 # クロスモデル比較
 bash scripts/multi-review.sh --mode cross-model --perspective code-review

--- a/scripts/agent-config.yaml
+++ b/scripts/agent-config.yaml
@@ -110,12 +110,3 @@ fallback:
   copilot-cli: codex-cli
   gemini-cli: codex-cli
   cursor-cli: codex-cli
-
-# ── pr-review-toolkit Delegation Mapping ──
-toolkit_delegation:
-  code-reviewer: codex-cli
-  silent-failure-hunter: codex-cli
-  type-design-analyzer: claude-code
-  pr-test-analyzer: codex-cli
-  comment-analyzer: gemini-cli
-  code-simplifier: cursor-cli

--- a/scripts/multi-agent.sh
+++ b/scripts/multi-agent.sh
@@ -26,7 +26,6 @@
 #   --output-dir <dir>      Output directory (auto-detected by task type)
 #   --base <branch>         Base branch for diff (default: develop)
 #   --include-diff          Include diff in implement prompts
-#   --delegate-toolkit      Delegate pr-review-toolkit perspectives
 #   --dry-run               Show plan without executing
 #   --timeout <seconds>     Timeout per CLI (auto-detected by task type)
 #   --help                  Show this help
@@ -186,7 +185,6 @@ STRATEGY=""
 PARALLEL=true
 OUTPUT_DIR=""
 BASE_BRANCH="develop"
-DELEGATE_TOOLKIT=false
 DRY_RUN=false
 TIMEOUT=""
 
@@ -232,7 +230,6 @@ parse_args() {
       --sequential)  PARALLEL=false; shift ;;
       --output-dir)  OUTPUT_DIR="$2"; shift 2 ;;
       --base)        BASE_BRANCH="$2"; shift 2 ;;
-      --delegate-toolkit) DELEGATE_TOOLKIT=true; shift ;;
       --dry-run)     DRY_RUN=true; shift ;;
       --timeout)     TIMEOUT="$2"; shift 2 ;;
       --help|-h)     show_help ;;

--- a/scripts/multi-agent.test.ts
+++ b/scripts/multi-agent.test.ts
@@ -129,6 +129,18 @@ describe("multi-agent.sh silent-failure guards", () => {
   });
 });
 
+describe("multi-agent.sh removed flags (issue #451)", () => {
+  // --delegate-toolkit はパース後どこからも参照されないデッドフラグだった
+  // （PR #449 の silent-failure-hunter が検出）。指定しても無言で無視され、
+  // 何も起きないのに成功したように見えていた。削除により未知オプション扱いとなり、
+  // *) 分岐で fail-loud（exit 1）する。無言で無視されないことを保証する回帰ガード。
+  it("--delegate-toolkit は削除済み — 未知オプションとして fail-loud で拒否される（exit 1）", () => {
+    const r = runScript(["--task", "review", "--delegate-toolkit", "--dry-run"]);
+    expect(r.status).toBe(1);
+    expect(r.output).toContain("Unknown option: --delegate-toolkit");
+  });
+});
+
 describe("multi-agent.sh config loading (set -e regression)", () => {
   const hasYq = spawnSync("bash", ["-c", "command -v yq"]).status === 0;
 


### PR DESCRIPTION
Closes #451

## 概要

`scripts/multi-agent.sh` の `--delegate-toolkit` は **パース後どこからも参照されないデッドフラグ**でした（PR #449 の silent-failure-hunter が検出）。指定しても無言で無視され、「何も起きないのに成功したように見える」誤解を生む状態でした。

Issue の 2 案（案1: 実装 / 案2: 削除）のうち、調査の結果 **案2（削除）** を選択しました。

## 案2 を選んだ根拠

1. **既定動作と重複** — `toolkit_delegation` が意図する CLI 割り当ては、`build_distributed_plan`（既定の分散プラン）がすでに実現しているクロスモデル分散とほぼ同一。実装しても既定の焼き直しにしかならない。
2. **命名の不整合** — `toolkit_delegation` のキー（`code-reviewer` 等 = pr-review-toolkit サブエージェント名）は、オーケストレーターの perspective 実体名（`code-review` / `error-handler-hunt` 等）と一致せず、対応する perspective ファイルも存在しない。実装するには二重の命名スキーマを新設・維持する必要があり乖離の温床。
3. **プロジェクト哲学** — less is more / YAGNI。未使用フラグは削除して案内と実態を一致させる。

## ⚠️ Breaking Change（意図的）

`--delegate-toolkit` は今後 **未知オプションとして exit 1（`Unknown option`）** になります。これは Issue #451 案2 の Test 要件「未知フラグとしてエラーになること」に沿った**意図的な挙動**です。

- このフラグは元々無効果（silent no-op）だったため、依存していたのは「エラーにならなかったこと」＝まさに本 Issue が解消したい誤解を招く silent success のみ。
- リポジトリ内で `--delegate-toolkit` を呼ぶ自動化（husky / CI / `.claude/hooks`）は**ゼロ**であることを検証済み（残存参照は回帰テストのみ）。
- Codex code-review が「互換性破壊」を指摘。互換レイヤー案は案2の要件と矛盾し、無効果フラグを警告付きで温存する元のアンチパターンへの逆戻りになるため採用せず、代わりに本節で明示。

## 変更内容

| ファイル | 変更 |
|---|---|
| `scripts/multi-agent.sh` | フラグ定義・パース分岐・ヘルプ行を削除。未知オプション → `*)` で **fail-loud（exit 1）** |
| `scripts/agent-config.yaml` | 未使用の `toolkit_delegation` マッピングを削除（`load_config` は元々未読の純粋なデッド設定） |
| `docs-template/.../multi-cli-review-orchestration.md` | 設定例・使用例から `--delegate-toolkit` / `toolkit_delegation` を削除 |
| `docs-template/.../REVIEW_AGENT_CREATION_GUIDE.md` | 「Toolkit移譲パターン」節・使用例・CLI IF・エントリーポイント表の該当箇所を削除。**対応表は既定動作の正確な文書として残し**、列名「移譲先CLI」→「担当CLI」に変更 |
| `scripts/multi-agent.test.ts` | 回帰テスト追加（`--delegate-toolkit` が exit 1 かつ `Unknown option` を返す） |

## テスト

- `npx vitest run scripts/multi-agent.test.ts` → **28 passed**（27→28、回帰テスト1件追加）
- `npm run quality:local` → docs検証100% / spec-index OK / format:md:check パス / lint:md 0エラー
- 手動確認: `bash scripts/multi-agent.sh --task review --delegate-toolkit --dry-run` → `Unknown option: --delegate-toolkit` / exit 1

## Issue の Test 要件（案2）との対応

- ✅ 未知フラグとしてエラーになること（exit 1 + `Unknown option`）
- ✅ ドキュメントに使用例が残っていないこと（`--delegate-toolkit` / `toolkit_delegation` / `移譲` の全残存を grep で 0 件確認）

## Follow-up

- #466 — docs の設定ファイル名ドリフト（`review-config.yaml` → `agent-config.yaml`）。本PRのレビュー中に検出した pre-existing な別件のため分離。