### PR TITLE
fix: #470 delegate review settings to CLI config

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -8,7 +8,7 @@
 # Env:
 #   SKIP_CODEX_REVIEW=1              Skip review
 #   REQUIRE_CODEX_REVIEW=1           Hard fail if codex CLI not found (default: soft skip)
-#   CODEX_MODEL=gpt-5.4              Override model (default: gpt-5.4)
+#   CODEX_MODEL                      Override model (default: Codex CLI config default)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
 
@@ -46,8 +46,14 @@ fi
 
 
 # Configuration
-CODEX_MODEL="${CODEX_MODEL:-gpt-5.4}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
+
+# モデルは既定では指定せず、~/.codex/config.toml に委譲する（ACE-70-2）。
+# env が明示された場合だけ -m を追加する。安全展開は macOS bash 3.2 + set -u 対応。
+CODEX_MODEL_ARGS=()
+if [ -n "${CODEX_MODEL:-}" ]; then
+    CODEX_MODEL_ARGS=("-m" "$CODEX_MODEL")
+fi
 
 # Resolve timeout command (GNU timeout or macOS gtimeout)
 TIMEOUT_CMD=""
@@ -63,11 +69,11 @@ invoke_cli() {
     local output=$2
 
     if [ -n "$TIMEOUT_CMD" ]; then
-        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" codex exec -m "$CODEX_MODEL" "$prompt" \
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" codex exec ${CODEX_MODEL_ARGS[@]+"${CODEX_MODEL_ARGS[@]}"} "$prompt" \
             < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
-        codex exec -m "$CODEX_MODEL" "$prompt" \
+        codex exec ${CODEX_MODEL_ARGS[@]+"${CODEX_MODEL_ARGS[@]}"} "$prompt" \
             < "$DIFF_FILE" > "$output"
     fi
 }
@@ -81,5 +87,6 @@ elif [ "$rc" -ne 0 ]; then
     exit 1  # Error
 fi
 
-run_all_reviewers "Codex Code Review (model: ${CODEX_MODEL})"
+MODEL_DISPLAY="${CODEX_MODEL:-codex config default}"
+run_all_reviewers "Codex Code Review (model: ${MODEL_DISPLAY})"
 exit $?

--- a/scripts/copilot-review.sh
+++ b/scripts/copilot-review.sh
@@ -9,7 +9,7 @@
 # Env:
 #   SKIP_COPILOT_REVIEW=1            Skip review
 #   REQUIRE_COPILOT_REVIEW=1         Hard fail if copilot CLI not found (default: soft skip)
-#   COPILOT_MODEL=claude-sonnet-4.5  Override model (default: claude-sonnet-4.5)
+#   COPILOT_MODEL                    Override model (default: Copilot CLI config default)
 #   REVIEW_BASE_BRANCH=main          Override base branch for --branch mode (default: develop)
 #   REVIEW_TIMEOUT_SEC=600           Max seconds per reviewer (default: 600)
 
@@ -47,8 +47,14 @@ fi
 
 
 # Configuration
-COPILOT_MODEL="${COPILOT_MODEL:-claude-sonnet-4.5}"
 REVIEW_TIMEOUT_SEC="${REVIEW_TIMEOUT_SEC:-600}"
+
+# モデルは既定では指定せず、Copilot CLI の設定／既定へ委譲する（ACE-70-2）。
+# env が明示された場合だけ --model を追加する。安全展開は macOS bash 3.2 + set -u 対応。
+COPILOT_MODEL_ARGS=()
+if [ -n "${COPILOT_MODEL:-}" ]; then
+    COPILOT_MODEL_ARGS=("--model" "$COPILOT_MODEL")
+fi
 
 # Resolve timeout command (GNU timeout or macOS gtimeout)
 TIMEOUT_CMD=""
@@ -64,11 +70,11 @@ invoke_cli() {
     local output=$2
 
     if [ -n "$TIMEOUT_CMD" ]; then
-        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" --model "$COPILOT_MODEL" \
+        "$TIMEOUT_CMD" "$REVIEW_TIMEOUT_SEC" copilot -p "$prompt" ${COPILOT_MODEL_ARGS[@]+"${COPILOT_MODEL_ARGS[@]}"} \
             < "$DIFF_FILE" > "$output"
     else
         echo -e "${YELLOW}Warning: 'timeout' command not found. No timeout protection.${NC}" >&2
-        copilot -p "$prompt" --model "$COPILOT_MODEL" \
+        copilot -p "$prompt" ${COPILOT_MODEL_ARGS[@]+"${COPILOT_MODEL_ARGS[@]}"} \
             < "$DIFF_FILE" > "$output"
     fi
 }
@@ -82,5 +88,6 @@ elif [ "$rc" -ne 0 ]; then
     exit 1  # Error
 fi
 
-run_all_reviewers "Copilot Code Review (model: ${COPILOT_MODEL})"
+MODEL_DISPLAY="${COPILOT_MODEL:-copilot config default}"
+run_all_reviewers "Copilot Code Review (model: ${MODEL_DISPLAY})"
 exit $?

--- a/scripts/review-cli-config.test.ts
+++ b/scripts/review-cli-config.test.ts
@@ -1,0 +1,161 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..");
+const BASE_PATH = "/usr/bin:/bin";
+
+function initFixtureRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "review-cli-config-fixture-"));
+  const git = (...args: string[]) => {
+    const result = spawnSync("git", args, {
+      cwd: dir,
+      encoding: "utf8",
+      env: {
+        PATH: BASE_PATH,
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+      },
+    });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`);
+    }
+  };
+
+  git("init", "-b", "develop");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "test");
+  writeFileSync(join(dir, "base.txt"), "base\n");
+  git("add", ".");
+  git("commit", "-m", "base");
+  git("switch", "-c", "test/config-delegation");
+  writeFileSync(join(dir, "change.txt"), "change\n");
+  git("add", ".");
+  git("commit", "-m", "change");
+  return dir;
+}
+
+function makeArgvStub(cli: "codex" | "copilot"): { dir: string; log: string } {
+  const dir = mkdtempSync(join(tmpdir(), `review-${cli}-argv-`));
+  const log = join(dir, "argv.log");
+  const body =
+    cli === "codex"
+      ? [
+          "flags=",
+          "while [ $# -gt 1 ]; do",
+          '  flags="${flags}<$1>"',
+          "  shift",
+          "done",
+        ]
+      : [
+          "flags=",
+          "while [ $# -gt 0 ]; do",
+          '  if [ "$1" = "-p" ] || [ "$1" = "--prompt" ]; then',
+          '    flags="${flags}<$1><__PROMPT__>"',
+          "    shift",
+          "    [ $# -eq 0 ] || shift",
+          "    continue",
+          "  fi",
+          '  flags="${flags}<$1>"',
+          "  shift",
+          "done",
+        ];
+
+  writeFileSync(
+    join(dir, cli),
+    [
+      "#!/bin/sh",
+      ...body,
+      'printf "%s\\n" "$flags" >> "$ARGV_LOG"',
+      "cat >/dev/null",
+      'echo "Verdict: PASS"',
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(dir, "timeout"), '#!/bin/sh\nshift\nexec "$@"\n');
+  chmodSync(join(dir, cli), 0o755);
+  chmodSync(join(dir, "timeout"), 0o755);
+  return { dir, log };
+}
+
+function captureArgv(
+  script: "codex-review.sh" | "copilot-review.sh",
+  cli: "codex" | "copilot",
+  env: Record<string, string>,
+): { calls: string[]; output: string; status: number | null } {
+  const repo = initFixtureRepo();
+  const stub = makeArgvStub(cli);
+  try {
+    const result = spawnSync(
+      "bash",
+      [join(REPO_ROOT, "scripts", script), "--branch"],
+      {
+        cwd: repo,
+        encoding: "utf8",
+        timeout: 60_000,
+        env: {
+          HOME: process.env.HOME,
+          TMPDIR: process.env.TMPDIR,
+          PATH: `${stub.dir}:${BASE_PATH}`,
+          ARGV_LOG: stub.log,
+          REVIEW_BASE_BRANCH: "develop",
+          ...env,
+        },
+      },
+    );
+    return {
+      calls: readFileSync(stub.log, "utf8").trim().split("\n"),
+      output: `${result.stdout}\n${result.stderr}`,
+      status: result.status,
+    };
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(stub.dir, { recursive: true, force: true });
+  }
+}
+
+describe("review CLI config delegation — Issue #470", () => {
+  it("Codex omits -m when unset and preserves an explicit model as one argv", () => {
+    const delegated = captureArgv("codex-review.sh", "codex", {});
+    expect(delegated.status).toBe(0);
+    expect(delegated.calls.every((call) => call === "<exec>")).toBe(true);
+    expect(delegated.output).toContain("model: codex config default");
+
+    const overridden = captureArgv("codex-review.sh", "codex", {
+      CODEX_MODEL: "gpt model override",
+    });
+    expect(overridden.status).toBe(0);
+    expect(
+      overridden.calls.every(
+        (call) => call === "<exec><-m><gpt model override>",
+      ),
+    ).toBe(true);
+  });
+
+  it("Copilot omits --model when unset and preserves an override as one argv", () => {
+    const delegated = captureArgv("copilot-review.sh", "copilot", {});
+    expect(delegated.status).toBe(0);
+    expect(delegated.calls.every((call) => call === "<-p><__PROMPT__>")).toBe(
+      true,
+    );
+    expect(delegated.output).toContain("model: copilot config default");
+
+    const overridden = captureArgv("copilot-review.sh", "copilot", {
+      COPILOT_MODEL: "copilot model override",
+    });
+    expect(overridden.status).toBe(0);
+    expect(
+      overridden.calls.every(
+        (call) => call === "<-p><__PROMPT__><--model><copilot model override>",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary\n- Delegate review wrapper models to CLI configuration when environment overrides are unset.\n- Add argv-boundary regression coverage for both delegated and explicit override paths.\n- Keep display output honest about config-derived values.\n\n## Validation\n- npx vitest run scripts/review-scripts.test.ts scripts/review-cli-config.test.ts: 52 passed\n- Review Toolkit 6 viewpoints: PASS\n- git diff --check: PASS\n- macOS Bash 3.2 compatibility path verified\n\nParent tracking issue: feel-flow/feelflow-plugins#241\n\nCloses #470